### PR TITLE
Fix FC045 to not fail if not metadata.rb file exists

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -73,11 +73,6 @@ module FoodCritic
     # @return [String] the value of the metadata field
     def metadata_field(file, field, options = {})
       options = { fail_on_nonexist: true }.merge!(options)
-
-      until (file.split(File::SEPARATOR) & standard_cookbook_subdirs).empty?
-        file = File.absolute_path(File.dirname(file.to_s))
-      end
-      file = File.dirname(file) unless File.extname(file).empty?
       cb_path = cookbook_base_path(file)
 
       # find value in metadata.rb if it exists

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -51,6 +51,8 @@ module FoodCritic
     # @param file [String, Pathname] relative or absolute path to a file in the cookbook
     # @return [String] the absolute path to the base of the cookbook
     def cookbook_base_path(file)
+      raise ArgumentError, "#{file} not found. You must supply a valid file" unless File.exist?(file)
+
       file = File.expand_path(file) # make sure we get an absolute path
       file = File.dirname(file) unless File.directory?(file) # get the dir only
 

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -51,7 +51,7 @@ module FoodCritic
     # @param file [String, Pathname] relative or absolute path to a file in the cookbook
     # @return [String] the absolute path to the base of the cookbook
     def cookbook_base_path(file)
-      raise ArgumentError, "#{file} not found. You must supply a valid file" unless File.exist?(file)
+      raise "#{file} not found. You must supply a valid file" unless File.exist?(file)
 
       file = File.expand_path(file) # make sure we get an absolute path
       file = File.dirname(file) unless File.directory?(file) # get the dir only
@@ -78,9 +78,10 @@ module FoodCritic
         file = File.absolute_path(File.dirname(file.to_s))
       end
       file = File.dirname(file) unless File.extname(file).empty?
+      cb_path = cookbook_base_path(file)
 
       # find value in metadata.rb if it exists
-      md_path = File.join(file, "metadata.rb")
+      md_path = File.join(cb_path, "metadata.rb")
       if File.exist?(md_path)
         value = read_ast(md_path).xpath("//stmts_add/
           command[ident/@value='#{field}']/
@@ -90,7 +91,7 @@ module FoodCritic
       end
 
       # if we didn't have metadata.rb we'll check metadata.json now
-      json_path = File.join(file, "metadata.json")
+      json_path = File.join(cb_path, "metadata.json")
       if File.exist?(json_path)
         json = json_file_to_hash(json_path)
         raise "Can't read #{field} from #{json_path}" if !json.key?(field) && options[:fail_on_nonexist]

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -114,11 +114,7 @@ module FoodCritic
       begin
         metadata_field(file, "name")
       rescue RuntimeError
-        until (file.split(File::SEPARATOR) & standard_cookbook_subdirs).empty?
-          file = File.absolute_path(File.dirname(file.to_s))
-        end
-        file = File.dirname(file) unless File.extname(file).empty?
-        File.basename(file)
+        File.basename(cookbook_base_path(file))
       end
     end
 

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -63,12 +63,15 @@ module FoodCritic
       file
     end
 
-    # Retrieves a value of a metadata field.
+    # Retrieves a metadata field. Defaults to metadata.rb and falls back
+    # to metadata.json
     #
     # @author Miguel Fonseca
     # @since 7.0.0
     # @return [String] the value of the metadata field
-    def metadata_field(file, field)
+    def metadata_field(file, field, options)
+      options = { fail_on_nonexist: true }.merge!(options)
+
       until (file.split(File::SEPARATOR) & standard_cookbook_subdirs).empty?
         file = File.absolute_path(File.dirname(file.to_s))
       end
@@ -79,10 +82,15 @@ module FoodCritic
         value = read_ast(md_path).xpath("//stmts_add/
           command[ident/@value='#{field}']/
           descendant::tstring_content/@value").to_s
-        raise "Cant read #{field} from #{md_path}" if value.to_s.empty?
+        raise "Can't read #{field} from #{md_path}" if value.to_s.empty? && options[:fail_on_nonexist]
         return value
+      elsif
+        json_path = File.join(file, "metadata.json")
+        json = json_file_to_hash(json_path)
+        raise "Can't read #{field} from #{json_path}" if !json.key?(field) && options[:fail_on_nonexist]
+        return json[field]
       else
-        raise "Cant find #{md_path}"
+        raise "Can't find #{md_path} or #{json_path}"
       end
     end
 

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -43,7 +43,6 @@ module FoodCritic
         standard_attribute_access(ast, options)
       end
     end
-
     # The absolute path of a cookbook from the specified file.
     #
     # @author Tim Smith - tsmith@chef.io
@@ -109,8 +108,10 @@ module FoodCritic
     def cookbook_name(file)
       raise ArgumentError, "File cannot be nil or empty" if file.to_s.empty?
 
-      # Name is a special case as we want to fallback to the cookbook directory
-      # name if metadata_field fails
+      # Determine the name of the cookbook given any file within the cookbook.
+      # Use metadata name property and fallback to dir name
+      #
+      # @return [String] the name of the cookbook
       begin
         metadata_field(file, "name")
       rescue RuntimeError

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -43,6 +43,7 @@ module FoodCritic
         standard_attribute_access(ast, options)
       end
     end
+
     # The absolute path of a cookbook from the specified file.
     #
     # @author Tim Smith - tsmith@chef.io

--- a/lib/foodcritic/rules/fc045.rb
+++ b/lib/foodcritic/rules/fc045.rb
@@ -1,6 +1,6 @@
 rule "FC045", "Metadata does not contain cookbook name" do
   tags %w{correctness metadata chef12}
-  metadata do |ast, filename|
-    [file_match(filename)] unless field(ast, "name").any?
+  cookbook do |filename|
+    [file_match(filename)] unless metadata_field(filename, "name", { fail_on_nonexist: false })
   end
 end

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -265,7 +265,7 @@ describe FoodCritic::Api do
     it "returns the cookbook maintainer when passed a template" do
       mock_cookbook_metadata(metadata_path)
       FileUtils.mkdir_p("/tmp/fc/mock/cb/templates/default/")
-      File.open('/tmp/fc/mock/cb/templates/default/mock.erb"', "w") { |file| file.write("") }
+      File.open("/tmp/fc/mock/cb/templates/default/mock.erb", "w") { |file| file.write("") }
       api.cookbook_maintainer("/tmp/fc/mock/cb/templates/default/mock.erb").must_equal "YOUR_COMPANY_NAME"
     end
   end

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -216,12 +216,22 @@ describe FoodCritic::Api do
     it "returns the cookbook name when passed a template" do
       erb_path = "cookbooks/apache2/templates/default/a2ensite.erb"
       expect(api.cookbook_name(erb_path)).to eq "apache2"
+    it "returns the cookbook name derived from the dir name not metadata" do
+      FileUtils.mkdir_p("/tmp/fc/cb2/")
+      File.open("/tmp/fc/cb2/metadata.rb", "w") { |file| file.write('chef_version ">= 12.1"') }
+      api.cookbook_name("/tmp/fc/cb2/metadata.rb").must_equal "cb2"
     end
     context "with a metadata.rb" do
       file "metadata.rb", 'name "YOUR_COOKBOOK_NAME"'
       it "returns the cookbook name when passed the cookbook metadata with a name field" do
         expect(api.cookbook_name(temp_path)).to eq "YOUR_COOKBOOK_NAME"
       end
+    end
+    it "returns the cookbook name when passed a recipe" do
+      FileUtils.mkdir_p("/tmp/fc/cb/recipes")
+      mock_cookbook_metadata("/tmp/fc/cb/metadata.rb")
+      File.open("/tmp/fc/cb/recipes/default.rb", "w") { |file| file.write("") }
+      api.cookbook_name("/tmp/fc/cb/recipes/default.rb").must_equal "YOUR_COOKBOOK_NAME"
     end
   end
 

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -185,7 +185,7 @@ describe FoodCritic::Api do
     end
 
     it "raises if a non-existent file is passed" do
-      lambda { api.cookbook_base_path("/tmp/something/that/doesnt/exist.rb") }.must_raise ArgumentError
+      lambda { api.cookbook_base_path("/tmp/something/that/doesnt/exist.rb") }.must_raise RuntimeError
     end
   end
 
@@ -246,6 +246,17 @@ describe FoodCritic::Api do
       it "returns the cookbook maintainer when passed a template" do
         expect(api.cookbook_maintainer("#{temp_path}/templates/default/mock.erb")).to eq "YOUR_COMPANY_NAME"
       end
+    it "returns the cookbook maintainer when passed a recipe" do
+      mock_cookbook_metadata(metadata_path)
+      FileUtils.mkdir_p("/tmp/fc/mock/cb/recipes/")
+      File.open("/tmp/fc/mock/cb/recipes/default.rb", "w") { |file| file.write("") }
+      api.cookbook_maintainer("/tmp/fc/mock/cb/recipes/default.rb").must_equal "YOUR_COMPANY_NAME"
+    end
+    it "returns the cookbook maintainer when passed a template" do
+      mock_cookbook_metadata(metadata_path)
+      FileUtils.mkdir_p("/tmp/fc/mock/cb/templates/default/")
+      File.open('/tmp/fc/mock/cb/templates/default/mock.erb"', "w") { |file| file.write("") }
+      api.cookbook_maintainer("/tmp/fc/mock/cb/templates/default/mock.erb").must_equal "YOUR_COMPANY_NAME"
     end
   end
 
@@ -270,6 +281,23 @@ describe FoodCritic::Api do
       it "returns the cookbook maintainer_email when passed a template" do
         expect(api.cookbook_maintainer_email("#{temp_path}/templates/default/mock.erb")).to eq "YOUR_EMAIL"
       end
+      lambda { api.cookbook_maintainer_email("/tmp/non-existent-path") }.must_raise RuntimeError
+    end
+    it "returns the cookbook maintainer_email when passed the cookbook metadata" do
+      mock_cookbook_metadata(metadata_path)
+      api.cookbook_maintainer_email(metadata_path).must_equal "YOUR_EMAIL"
+    end
+    it "returns the cookbook maintainer_email when passed a recipe" do
+      mock_cookbook_metadata(metadata_path)
+      FileUtils.mkdir_p("/tmp/fc/mock/cb/recipes/")
+      File.open("/tmp/fc/mock/cb/recipes/default.rb", "w") { |file| file.write("") }
+      api.cookbook_maintainer_email("/tmp/fc/mock/cb/recipes/default.rb").must_equal "YOUR_EMAIL"
+    end
+    it "returns the cookbook maintainer_email when passed a template" do
+      mock_cookbook_metadata(metadata_path)
+      FileUtils.mkdir_p("/tmp/fc/mock/cb/templates/default/")
+      File.open("/tmp/fc/mock/cb/templates/default/mock.erb", "w") { |file| file.write("") }
+      api.cookbook_maintainer_email("/tmp/fc/mock/cb/templates/default/mock.erb").must_equal "YOUR_EMAIL"
     end
   end
 

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -184,6 +184,11 @@ describe FoodCritic::Api do
       end
     end
 
+    it "raises if a non-existent file is passed" do
+      lambda { api.cookbook_base_path("/tmp/something/that/doesnt/exist.rb") }.must_raise ArgumentError
+    end
+  end
+
     context "with complex nested folders with metadata.rb" do
       file "metadata.rb"
       file "templates/metadata.rb"

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -189,73 +189,74 @@ describe FoodCritic::Api do
     end
   end
 
-    context "with complex nested folders with metadata.rb" do
-      file "metadata.rb"
-      file "templates/metadata.rb"
+  context "with complex nested folders with metadata.rb" do
+    file "metadata.rb"
+    file "templates/metadata.rb"
 
-      it "returns the cookbook dir when path contains cookbook like names" do
-        expect(api.cookbook_base_path("#{temp_path}/templates/defaults/test.erb")).to eq "#{temp_path}/templates"
-      end
+    it "returns the cookbook dir when path contains cookbook like names" do
+      expect(api.cookbook_base_path("#{temp_path}/templates/defaults/test.erb")).to eq "#{temp_path}/templates"
     end
   end
+end
 
-  describe "#cookbook_name" do
-    it "raises if passed a nil" do
-      expect { api.cookbook_name(nil) }.to raise_error ArgumentError
-    end
-    it "raises if passed an empty string" do
-      expect { api.cookbook_name("") }.to raise_error ArgumentError
-    end
-    it "returns the cookbook name when passed a recipe" do
-      recipe_path = "cookbooks/apache2/recipes/default.rb"
-      expect(api.cookbook_name(recipe_path)).to eq "apache2"
-    end
-    it "returns the cookbook name when passed the cookbook metadata" do
-      expect(api.cookbook_name("cookbooks/apache2/metadata.rb")).to eq "apache2"
-    end
-    it "returns the cookbook name when passed a template" do
-      erb_path = "cookbooks/apache2/templates/default/a2ensite.erb"
-      expect(api.cookbook_name(erb_path)).to eq "apache2"
-    it "returns the cookbook name derived from the dir name not metadata" do
-      FileUtils.mkdir_p("/tmp/fc/cb2/")
-      File.open("/tmp/fc/cb2/metadata.rb", "w") { |file| file.write('chef_version ">= 12.1"') }
-      api.cookbook_name("/tmp/fc/cb2/metadata.rb").must_equal "cb2"
-    end
-    context "with a metadata.rb" do
-      file "metadata.rb", 'name "YOUR_COOKBOOK_NAME"'
-      it "returns the cookbook name when passed the cookbook metadata with a name field" do
-        expect(api.cookbook_name(temp_path)).to eq "YOUR_COOKBOOK_NAME"
-      end
-    end
-    it "returns the cookbook name when passed a recipe" do
-      FileUtils.mkdir_p("/tmp/fc/cb/recipes")
-      mock_cookbook_metadata("/tmp/fc/cb/metadata.rb")
-      File.open("/tmp/fc/cb/recipes/default.rb", "w") { |file| file.write("") }
-      api.cookbook_name("/tmp/fc/cb/recipes/default.rb").must_equal "YOUR_COOKBOOK_NAME"
+describe "#cookbook_name" do
+  it "raises if passed a nil" do
+    expect { api.cookbook_name(nil) }.to raise_error ArgumentError
+  end
+  it "raises if passed an empty string" do
+    expect { api.cookbook_name("") }.to raise_error ArgumentError
+  end
+  it "returns the cookbook name when passed a recipe" do
+    recipe_path = "cookbooks/apache2/recipes/default.rb"
+    expect(api.cookbook_name(recipe_path)).to eq "apache2"
+  end
+  it "returns the cookbook name when passed the cookbook metadata" do
+    expect(api.cookbook_name("cookbooks/apache2/metadata.rb")).to eq "apache2"
+  end
+  it "returns the cookbook name when passed a template" do
+    erb_path = "cookbooks/apache2/templates/default/a2ensite.erb"
+    expect(api.cookbook_name(erb_path)).to eq "apache2"
+  end
+  it "returns the cookbook name derived from the dir name not metadata" do
+    FileUtils.mkdir_p("/tmp/fc/cb2/")
+    File.open("/tmp/fc/cb2/metadata.rb", "w") { |file| file.write('chef_version ">= 12.1"') }
+    api.cookbook_name("/tmp/fc/cb2/metadata.rb").must_equal "cb2"
+  end
+  context "with a metadata.rb" do
+    file "metadata.rb", 'name "YOUR_COOKBOOK_NAME"'
+    it "returns the cookbook name when passed the cookbook metadata with a name field" do
+      expect(api.cookbook_name(temp_path)).to eq "YOUR_COOKBOOK_NAME"
     end
   end
+  it "returns the cookbook name when passed a recipe" do
+    FileUtils.mkdir_p("/tmp/fc/cb/recipes")
+    mock_cookbook_metadata("/tmp/fc/cb/metadata.rb")
+    File.open("/tmp/fc/cb/recipes/default.rb", "w") { |file| file.write("") }
+    api.cookbook_name("/tmp/fc/cb/recipes/default.rb").must_equal "YOUR_COOKBOOK_NAME"
+  end
+end
 
-  describe "#cookbook_maintainer" do
-    it "raises if passed a nil" do
-      expect { api.cookbook_maintainer(nil) }.to raise_error ArgumentError
+describe "#cookbook_maintainer" do
+  it "raises if passed a nil" do
+    expect { api.cookbook_maintainer(nil) }.to raise_error ArgumentError
+  end
+  it "raises if passed an empty string" do
+    expect { api.cookbook_maintainer("") }.to raise_error ArgumentError
+  end
+  it "raises if the path does not exist" do
+    expect { api.cookbook_maintainer("/invalid") }.to raise_error RuntimeError
+  end
+  context "with a metadata.rb" do
+    file "metadata.rb", 'maintainer "YOUR_COMPANY_NAME"'
+    it "returns the cookbook maintainer when passed the cookbook metadata" do
+      expect(api.cookbook_maintainer(temp_path)).to eq "YOUR_COMPANY_NAME"
     end
-    it "raises if passed an empty string" do
-      expect { api.cookbook_maintainer("") }.to raise_error ArgumentError
+    it "returns the cookbook maintainer when passed a recipe" do
+      expect(api.cookbook_maintainer("#{temp_path}/recipes/default.rb")).to eq "YOUR_COMPANY_NAME"
     end
-    it "raises if the path does not exist" do
-      expect { api.cookbook_maintainer("/invalid") }.to raise_error RuntimeError
+    it "returns the cookbook maintainer when passed a template" do
+      expect(api.cookbook_maintainer("#{temp_path}/templates/default/mock.erb")).to eq "YOUR_COMPANY_NAME"
     end
-    context "with a metadata.rb" do
-      file "metadata.rb", 'maintainer "YOUR_COMPANY_NAME"'
-      it "returns the cookbook maintainer when passed the cookbook metadata" do
-        expect(api.cookbook_maintainer(temp_path)).to eq "YOUR_COMPANY_NAME"
-      end
-      it "returns the cookbook maintainer when passed a recipe" do
-        expect(api.cookbook_maintainer("#{temp_path}/recipes/default.rb")).to eq "YOUR_COMPANY_NAME"
-      end
-      it "returns the cookbook maintainer when passed a template" do
-        expect(api.cookbook_maintainer("#{temp_path}/templates/default/mock.erb")).to eq "YOUR_COMPANY_NAME"
-      end
     it "returns the cookbook maintainer when passed a recipe" do
       mock_cookbook_metadata(metadata_path)
       FileUtils.mkdir_p("/tmp/fc/mock/cb/recipes/")
@@ -1958,7 +1959,6 @@ describe FoodCritic::Api do
   end
 
   describe "#json_file_to_hash" do
-
     it "raises if the filename is not provided" do
       expect { api.json_file_to_hash }.to raise_error ArgumentError
     end


### PR DESCRIPTION
So it turns out all our metadata checks don't work on the Supermarket if you uploaded using stove which strips off the metadata.json. Most just silently skip, but FC045 hard fails, which is not the desired way to do this. Instead lets just try to return the name value starting with metadata.rb and failing back to metadata.json. We'll raise if that doesn't return anything. Assuming people like this pattern we can update the other metadata checks to use the same pattern.