### PR TITLE
Add FC085: Resource using new_resource.updated_by_last_action to converge resource

### DIFF
--- a/lib/foodcritic/rules/fc085.rb
+++ b/lib/foodcritic/rules/fc085.rb
@@ -1,0 +1,12 @@
+rule "FC085", "Resource using new_resource.updated_by_last_action to converge resource" do
+  tags %w{chef13 deprecated}
+  def updated_by(ast)
+    ast.xpath('//call[(vcall|var_ref)/ident/@value="new_resource"]
+      [ident/@value="updated_by_last_action"]')
+  end
+
+  resource { |ast| updated_by(ast) }
+  provider { |ast| updated_by(ast) }
+  library { |ast| updated_by(ast) }
+
+end

--- a/spec/functional/fc085_spec.rb
+++ b/spec/functional/fc085_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+describe "FC085" do
+  context "with a cookbook with a custom resource that converges with updated_by_last_action" do
+    resource_file <<-EOF
+    action :create do
+      template "/etc/something.conf" do
+        notifies :restart, "service[something]"
+      end
+
+      new_resource.updated_by_last_action(true)
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a LWRP that converges with updated_by_last_action" do
+    resource_file <<-EOF
+    use_inline_resources
+
+    action :create do
+      template "/etc/something.conf" do
+        notifies :restart, "service[something]"
+      end
+
+      new_resource.updated_by_last_action(true)
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a custom resource that relies on resources for convergence" do
+    resource_file <<-EOF
+    action :create do
+      file "the_file" do
+        template "/etc/something.conf" do
+          notifies :restart, "service[something]"
+        end
+      end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
+
+  context "with a cookbook with a LWRP that relies on resources for convergence" do
+    resource_file <<-EOF
+    use_inline_resources
+
+    action :create do
+      file "the_file" do
+        template "/etc/something.conf" do
+          notifies :restart, "service[something]"
+        end
+      end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
+
+end


### PR DESCRIPTION
There's so much misuse of this pattern in our cookbooks. With use_inline_resources turned on by default now there's no reason to ever use it. We need to point people to simple pure chef resource based converges or to converge_by when they're writing their own ruby code in resources

Signed-off-by: Tim Smith <tsmith@chef.io>