### PR TITLE
Add option to specify foodcritic rule file

### DIFF
--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -46,6 +46,10 @@ module FoodCritic
                 "of Chef.") do |c|
           @options[:chef_version] = c
         end
+         opts.on("-r", "--rule-file PATH",
+                "Specify file with rules to be used or ignored ") do |c|
+          @options[:rule_file] = c
+        end
         opts.on("-B", "--cookbook-path PATH",
                 "Cookbook path(s) to check.") do |b|
           @options[:cookbook_paths] << b

--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -46,7 +46,7 @@ module FoodCritic
                 "of Chef.") do |c|
           @options[:chef_version] = c
         end
-         opts.on("-r", "--rule-file PATH",
+        opts.on("-r", "--rule-file PATH",
                 "Specify file with rules to be used or ignored ") do |c|
           @options[:rule_file] = c
         end

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -201,7 +201,7 @@ module FoodCritic
 
     def cookbook_tags(file)
       tags = []
-      fc_file = "#{cookbook_dir(file)}/.foodcritic"
+      fc_file = @options[:rule_file] || "#{cookbook_dir(file)}/.foodcritic"
       if File.exist? fc_file
         begin
           tag_text = File.read fc_file

--- a/spec/unit/command_line_spec.rb
+++ b/spec/unit/command_line_spec.rb
@@ -119,4 +119,18 @@ describe FoodCritic::CommandLine do
       expect(FoodCritic::CommandLine.new(["--no-context", "."]).show_context?).to be_falsey
     end
   end
+
+  describe ":rule_file" do
+    it "is unset if -r/--rule-file is not specified" do
+      expect(FoodCritic::CommandLine.new(["."]).options[:rule_file].nil?).to be_truthy
+    end
+
+    it "is equal to the provided path if -r is set and path is specified" do
+      expect(FoodCritic::CommandLine.new(["-r", "example", "."]).options[:rule_file]).to eq "example"
+    end
+
+    it "is equal to the provided path if --rule-file is set and path is specified" do
+      expect(FoodCritic::CommandLine.new(["--rule-file", "example", "."]).options[:rule_file]).to eq "example"
+    end
+  end
 end


### PR DESCRIPTION
I have added a very simple way to use a specific file with foodcritic rules instead of always looking for .foodcritic in the root of a cookbook. 