### PR TITLE
Add FC089 to detect usage of Chef::ShellOut

### DIFF
--- a/lib/foodcritic/rules/fc089.rb
+++ b/lib/foodcritic/rules/fc089.rb
@@ -1,0 +1,11 @@
+rule "FC089", "Prefer Mixlib::Shellout over Chef::ShellOut" do
+  tags %w{chef13 deprecated}
+
+  def old_shellout(ast)
+    ast.xpath('//const[@value="ShellOut"]/..//const[@value="Chef"]')
+  end
+
+  resource { |ast| old_shellout(ast) }
+  recipe { |ast| old_shellout(ast) }
+  library { |ast| old_shellout(ast) }
+end

--- a/spec/functional/fc089_spec.rb
+++ b/spec/functional/fc089_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "FC089" do
+  context "with a cookbook with a library that uses Chef::ShellOut" do
+    library_file "include Chef::ShellOut"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a resource that uses Chef::ShellOut" do
+    resource_file "include Chef::ShellOut"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a resource that uses Miblib::Shellout" do
+    resource_file "include Mixlib::Shellout"
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
Another Chef 13 deprecation

Signed-off-by: Tim Smith <tsmith@chef.io>