### PR TITLE
Docker to Foodcritic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:2.4-alpine
+
+ARG BUNDLER_ARGS="--jobs 3 --retry 3"
+
+RUN adduser -h /foodcritic -g foodcritic -D foodcritic
+
+COPY . /foodcritic
+
+WORKDIR /foodcritic
+
+RUN set -ex && \
+  # install dependencies
+  apk add --no-cache --virtual alpine-sdk && \
+  bundle install --system $BUNDLER_ARGS && \
+  bundle exec rake
+
+RUN chown -R foodcritic:foodcritic /foodcritic
+
+USER foodcritic
+
+ENTRYPOINT ["/foodcritic/bin/foodcritic"]
+CMD ["/foodcritic/bin/foodcritic","--help"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ Running regression tests:
 $ bundle exec rake 'spec[regression]'
 ```
 
+## Docker
+
+Foodcritic can also be used with Docker. To build and run Foodcritic in a Docker container please follow the instructions below.
+
+Building the Docker image:
+
+```shell
+$ docker build --rm -t foodcritic/foodcritic .
+```
+
+Running Foodcritic inside a Docker container:
+
+```shell
+$ docker run -it --rm -v ~/cookbooks:/cookbooks foodcritic/foodcritic "/cookbooks"
+```
+
+**Note:** This will mount the host directory `~/cookbooks` into the container in the path `/cookbooks`.
+
 ## License
 
 MIT - see the accompanying [LICENSE](https://github.com/acrmp/foodcritic/blob/master/LICENSE) file for details.


### PR DESCRIPTION
Just a simple Docker image that helps the use of Foodcritic inside a CI tool without the need to download and build the latest version, for example.

I also added a basic info on how to use it.

If you guys think is relevant, we can also create a organization in [Docker Hub](https://hub.docker.com/) so people can pull the image without the need to build it, like `docker pull foodcritic/foodcritic`.