### PR TITLE
Switch from yajl-ruby to ffi-yajl

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency("nokogiri", ">= 1.5", "< 2.0")
   s.add_dependency("rake")
   s.add_dependency("treetop", "~> 1.4")
-  s.add_dependency("yajl-ruby", "~> 1.1")
+  s.add_dependency("ffi-yajl", "~> 2.0")
   s.add_dependency("erubis")
   s.add_dependency("rufus-lru", "~> 1.0")
 

--- a/lib/foodcritic.rb
+++ b/lib/foodcritic.rb
@@ -2,7 +2,7 @@ require "pathname"
 require "cucumber/core"
 require "treetop"
 require "ripper"
-require "yajl"
+require "ffi_yajl"
 require "erubis"
 
 require_relative "foodcritic/chef"

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -424,7 +424,7 @@ module FoodCritic
       file = File.read(filename)
       begin
         FFI_Yajl::Parser.parse(file)
-      rescue RuntimeError
+      rescue FFI_Yajl::ParseError
         raise "File #{filename} does not appear to contain valid JSON"
       end
     end

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -1,6 +1,5 @@
 require "nokogiri"
 require "rufus-lru"
-require "json"
 
 module FoodCritic
   # Helper methods that form part of the Rules DSL.
@@ -424,7 +423,7 @@ module FoodCritic
 
       file = File.read(filename)
       begin
-        JSON.parse(file)
+        FFI_Yajl::Parser.parse(file)
       rescue RuntimeError
         raise "File #{filename} does not appear to contain valid JSON"
       end

--- a/lib/foodcritic/chef.rb
+++ b/lib/foodcritic/chef.rb
@@ -55,7 +55,7 @@ module FoodCritic
         Linter::DEFAULT_CHEF_VERSION].map do |version|
           metadata_path(version)
         end.find { |m| File.exist?(m) }
-      @dsl_metadata ||= Yajl::Parser.parse(IO.read(metadata_path),
+      @dsl_metadata ||= FFI_Yajl::Parser.parse(IO.read(metadata_path),
                                            symbolize_keys: true)
     end
 

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -1928,7 +1928,7 @@ describe FoodCritic::Api do
     it "raises if the json is not valid" do
       expect(::File).to receive(:exist?).with("/some/path/with/a/file").and_return(true)
       allow(File).to receive(:read).with("/some/path/with/a/file").and_return("I am bogus data")
-      expect { api.json_file_to_hash("/some/path/with/a/file") }.to raise_error JSON::ParserError
+      expect { api.json_file_to_hash("/some/path/with/a/file") }.to raise_error RuntimeError
     end
   end
 


### PR DESCRIPTION
ffi-yajl is used by Chef already so this is one less requirement in ChefDK. yajl-ruby install size in macOS ChefDK is 3.8M

Signed-off-by: Tim Smith <tsmith@chef.io>