### PR TITLE
Limit the files we ship in the gem

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -12,12 +12,9 @@ Gem::Specification.new do |s|
   s.executables << "foodcritic"
   s.required_ruby_version = ">= 2.2.2"
 
-  s.files = Dir["chef_dsl_metadata/*.json"] +
-    Dir["lib/**/*.rb"] +
-    Dir["misc/**/*"]
-  s.files += Dir["Rakefile"] + Dir["Gemfile"] + Dir["*.gemspec"]
-  s.files += Dir["spec/**/*"] + Dir["features/**/*"]
-  s.files += Dir["*.md"] + Dir["LICENSE"] + Dir["man/*"]
+  s.files = Dir["chef_dsl_metadata/*.json"] + Dir["lib/**/*.rb"] +
+    Dir["misc/**/*"] + Dir["*.gemspec"] + Dir["*.md"] + Dir["LICENSE"] +
+    Dir["man/*"]
 
   s.add_dependency("cucumber-core", ">= 1.3")
   s.add_dependency("nokogiri", ">= 1.5", "< 2.0")


### PR DESCRIPTION
Strip out the following files:

Gemfile
Rakefile
specs
features

This drops our gem from 269kb to 205k and the install size drops from 7.5M to 6.5M

Signed-off-by: Tim Smith <tsmith@chef.io>