### PR TITLE
Allow EncryptedDataBagItem.load_secret in FC086

### DIFF
--- a/lib/foodcritic/rules/fc086.rb
+++ b/lib/foodcritic/rules/fc086.rb
@@ -1,7 +1,7 @@
 rule "FC086", "Use databag helper methods to load data bag items" do
   tags %w{style}
   def old_dbag(ast)
-    ast.xpath('//const_path_ref/const[@value="EncryptedDataBagItem" or @value="DataBagItem"]/..//const[@value="Chef"]/../../..')
+    ast.xpath('//const_path_ref/const[@value="EncryptedDataBagItem" or @value="DataBagItem"]/..//const[@value="Chef"]/../../..//ident[@value!="load_secret"]/..')
   end
 
   resource { |ast| old_dbag(ast) }

--- a/spec/functional/fc086_spec.rb
+++ b/spec/functional/fc086_spec.rb
@@ -1,17 +1,17 @@
 require "spec_helper"
 
 describe "FC086" do
-  context "with a cookbook with a recipe that uses Chef::EncryptedDataBagItem.load_secret" do
+  context "with a recipe that uses Chef::EncryptedDataBagItem.load" do
     recipe_file 'Chef::EncryptedDataBagItem.load("users", "tsmith", key)'
     it { is_expected.to violate_rule }
   end
 
-  context "with a cookbook with a recipe that uses Chef::DataBagItem.load" do
+  context "with a recipe that uses Chef::DataBagItem.load" do
     recipe_file 'Chef::DataBagItem.load("users", "tsmith")'
     it { is_expected.to violate_rule }
   end
 
-  context "with a cookbook with a resource that uses Chef::EncryptedDataBagItem.load_secret" do
+  context "with a resource that uses Chef::EncryptedDataBagItem.load" do
     resource_file <<-EOF
       action :create do
         data = Chef::EncryptedDataBagItem.load("users", "tsmith", key)
@@ -20,7 +20,7 @@ describe "FC086" do
     it { is_expected.to violate_rule }
   end
 
-  context "with a cookbook with a resource that uses Chef::EncryptedDataBagItem.load_secret" do
+  context "with a resource that uses Chef::DataBagItem.load" do
     resource_file <<-EOF
       action :create do
         data = Chef::DataBagItem.load("users", "tsmith")
@@ -29,8 +29,8 @@ describe "FC086" do
     it { is_expected.to violate_rule }
   end
 
-  context "with a cookbook with a resource that uses data_bag_item" do
-    recipe_file "data_bag_item('bag', 'item', IO.read('secret_file'))"
+  context "with a recipe that uses data_bag_item" do
+    recipe_file "data_bag_item('bag', 'item', IO.read('secret_file').strip)"
     it { is_expected.not_to violate_rule }
   end
 end

--- a/spec/functional/fc086_spec.rb
+++ b/spec/functional/fc086_spec.rb
@@ -33,4 +33,9 @@ describe "FC086" do
     recipe_file "data_bag_item('bag', 'item', IO.read('secret_file').strip)"
     it { is_expected.not_to violate_rule }
   end
+
+  context "with a recipe that uses Chef::EncryptedDataBagItem.load_secret" do
+    recipe_file "data_bag_item('bag', 'item', Chef::EncryptedDataBagItem.load_secret('secret_file'))"
+    it { is_expected.not_to violate_rule }
+  end
 end


### PR DESCRIPTION
`IO.read` isn't equivalent because of trailing whitespace. `load_secret` isn't incorrect to use IMO if you have more than one bag secret (though that itself is a terrible idea, but moving on).

Also tweaked the spec labels to match the tests.