### PR TITLE
FC090: Resource should not ignore failures.

### DIFF
--- a/lib/foodcritic/rules/fc090.rb
+++ b/lib/foodcritic/rules/fc090.rb
@@ -1,6 +1,6 @@
 rule "FC090", "Resource should not ignore failures" do
   tags %w{correctness resource}
   recipe do |ast|
-    find_resources(ast).select { |resource| resource_attributes(resource)['ignore_failure'] }.compact
+    find_resources(ast).select { |resource| resource_attributes(resource)["ignore_failure"] }.compact
   end
 end

--- a/lib/foodcritic/rules/fc090.rb
+++ b/lib/foodcritic/rules/fc090.rb
@@ -1,0 +1,6 @@
+rule "FC090", "Resource should not ignore failures" do
+  tags %w{correctness resource}
+  recipe do |ast|
+    find_resources(ast).select { |resource| resource_attributes(resource)['ignore_failure'] }.compact
+  end
+end

--- a/lib/foodcritic/rules/fc090.rb
+++ b/lib/foodcritic/rules/fc090.rb
@@ -1,5 +1,5 @@
 rule "FC090", "Resource should not ignore failures" do
-  tags %w{correctness resource}
+  tags %w{resource}
   recipe do |ast|
     find_resources(ast).select { |resource| resource_attributes(resource)["ignore_failure"] }.compact
   end

--- a/spec/functional/fc090_spec.rb
+++ b/spec/functional/fc090_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "FC090" do
   context "with a recipe that installs package with ignore_failure set true" do

--- a/spec/functional/fc090_spec.rb
+++ b/spec/functional/fc090_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe 'FC090' do
-  context 'with a cookbook that installs package with ignore_failure set true' do
+describe "FC090" do
+  context "with a recipe that installs package with ignore_failure set true" do
     recipe_file <<-EOF
         package 'foo' do
           ignore_failure true
@@ -10,7 +10,7 @@ describe 'FC090' do
     it { is_expected.to violate_rule }
   end
 
-  context 'with a cookbook that installs package with ignore_failure set false' do
+  context "with a recipe that installs package with ignore_failure set false" do
     recipe_file <<-EOF
         package 'foo' do
           ignore_failure false
@@ -19,7 +19,7 @@ describe 'FC090' do
     it { is_expected.not_to violate_rule }
   end
 
-  context 'with a cookbook that installs package without defining ignore_failure' do
+  context "with a recipe that installs package without defining ignore_failure" do
     recipe_file "package 'foo'"
     it { is_expected.not_to violate_rule }
   end

--- a/spec/functional/fc090_spec.rb
+++ b/spec/functional/fc090_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'FC090' do
+  context 'with a cookbook that installs package with ignore_failure set true' do
+    recipe_file <<-EOF
+        package 'foo' do
+          ignore_failure true
+        end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context 'with a cookbook that installs package with ignore_failure set false' do
+    recipe_file <<-EOF
+        package 'foo' do
+          ignore_failure false
+        end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+
+  context 'with a cookbook that installs package without defining ignore_failure' do
+    recipe_file "package 'foo'"
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
/cc @jonlives @coderanger @tas50 

This foodcritic rule fails if any resource sets [ignore_failure
true](https://docs.chef.io/resource_common.html#properties) property.