### PR TITLE
Add FC097, FC098, FC099, and FC100 for deprecated mixin usage

### DIFF
--- a/lib/foodcritic/rules/fc097.rb
+++ b/lib/foodcritic/rules/fc097.rb
@@ -1,0 +1,11 @@
+rule "FC097", "Deprecated Chef::Mixin::LanguageIncludeAttribute class used" do
+  tags %w{chef14 deprecated}
+  def lang_include_attrib_mixin(ast)
+    # include Chef::Mixin::LanguageIncludeAttribute
+    ast.xpath('//const_path_ref/const[@value="LanguageIncludeAttribute"]/..//const[@value="Mixin"]/..//const[@value="Chef"]')
+  end
+  recipe { |ast| lang_include_attrib_mixin(ast) }
+  library { |ast| lang_include_attrib_mixin(ast) }
+  resource { |ast| lang_include_attrib_mixin(ast) }
+
+end

--- a/lib/foodcritic/rules/fc098.rb
+++ b/lib/foodcritic/rules/fc098.rb
@@ -1,0 +1,11 @@
+rule "FC098", "Deprecated Chef::Mixin::RecipeDefinitionDSLCore class used" do
+  tags %w{chef14 deprecated}
+  def recipe_def_mixin(ast)
+    # include Chef::Mixin::RecipeDefinitionDSLCore
+    ast.xpath('//const_path_ref/const[@value="RecipeDefinitionDSLCore"]/..//const[@value="Mixin"]/..//const[@value="Chef"]')
+  end
+  recipe { |ast| recipe_def_mixin(ast) }
+  library { |ast| recipe_def_mixin(ast) }
+  resource { |ast| recipe_def_mixin(ast) }
+
+end

--- a/lib/foodcritic/rules/fc099.rb
+++ b/lib/foodcritic/rules/fc099.rb
@@ -1,0 +1,11 @@
+rule "FC099", "Deprecated Chef::Mixin::LanguageIncludeRecipe class used" do
+  tags %w{chef14 deprecated}
+  def lang_include_mixin(ast)
+    # include Chef::Mixin::LanguageIncludeRecipe
+    ast.xpath('//const_path_ref/const[@value="LanguageIncludeRecipe"]/..//const[@value="Mixin"]/..//const[@value="Chef"]')
+  end
+  recipe  { |ast| lang_include_mixin(ast) }
+  library { |ast| lang_include_mixin(ast) }
+  resource { |ast| lang_include_mixin(ast) }
+
+end

--- a/lib/foodcritic/rules/fc100.rb
+++ b/lib/foodcritic/rules/fc100.rb
@@ -1,0 +1,11 @@
+rule "FC100", "Deprecated Chef::Mixin::Language class used" do
+  tags %w{chef14 deprecated}
+  def lang_mixin(ast)
+    # include Chef::Mixin::Language
+    ast.xpath('//const_path_ref/const[@value="Language"]/..//const[@value="Mixin"]/..//const[@value="Chef"]')
+  end
+  recipe  { |ast| lang_mixin(ast) }
+  library { |ast| lang_mixin(ast) }
+  resource { |ast| lang_mixin(ast) }
+
+end

--- a/spec/functional/fc097_spec.rb
+++ b/spec/functional/fc097_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "FC097" do
+  context "with a cookbook with a custom resource that includes Chef::Mixin::LanguageIncludeAttribute" do
+    resource_file "include Chef::Mixin::LanguageIncludeAttribute"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that includes Chef::Mixin::LanguageIncludeAttribute" do
+    recipe_file "include Chef::Mixin::LanguageIncludeAttribute"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a library that includes Chef::Mixin::LanguageIncludeAttribute" do
+    library_file "include Chef::Mixin::LanguageIncludeAttribute"
+    it { is_expected.to violate_rule }
+  end
+end

--- a/spec/functional/fc098_spec.rb
+++ b/spec/functional/fc098_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "FC098" do
+  context "with a cookbook with a custom resource that includes Chef::Mixin::RecipeDefinitionDSLCore" do
+    resource_file "include Chef::Mixin::RecipeDefinitionDSLCore"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that includes Chef::Mixin::RecipeDefinitionDSLCore" do
+    recipe_file "include Chef::Mixin::RecipeDefinitionDSLCore"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a library that includes Chef::Mixin::RecipeDefinitionDSLCore" do
+    library_file "include Chef::Mixin::RecipeDefinitionDSLCore"
+    it { is_expected.to violate_rule }
+  end
+end

--- a/spec/functional/fc099_spec.rb
+++ b/spec/functional/fc099_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "FC099" do
+  context "with a cookbook with a custom resource that includes Chef::Mixin::LanguageIncludeRecipe" do
+    resource_file "include Chef::Mixin::LanguageIncludeRecipe"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that includes Chef::Mixin::LanguageIncludeRecipe" do
+    recipe_file "include Chef::Mixin::LanguageIncludeRecipe"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a library that includes Chef::Mixin::LanguageIncludeRecipe" do
+    library_file "include Chef::Mixin::LanguageIncludeRecipe"
+    it { is_expected.to violate_rule }
+  end
+end

--- a/spec/functional/fc100_spec.rb
+++ b/spec/functional/fc100_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "FC100" do
+  context "with a cookbook with a custom resource that includes Chef::Mixin::Language" do
+    resource_file "include Chef::Mixin::Language"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that includes Chef::Mixin::Languagee" do
+    recipe_file "include Chef::Mixin::Language"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a library that includes Chef::Mixin::Language" do
+    library_file "include Chef::Mixin::Language"
+    it { is_expected.to violate_rule }
+  end
+end


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>