### PR TITLE
Fix deprecation tags and descriptions

### DIFF
--- a/lib/foodcritic/rules/fc094.rb
+++ b/lib/foodcritic/rules/fc094.rb
@@ -1,5 +1,5 @@
 rule "FC094", "Cookbook uses deprecated filesystem2 ohai plugin data" do
-  tags %w{deprecated chef13}
+  tags %w{deprecated chef15}
 
   recipe do |ast|
     ast.xpath('//aref[vcall/ident/@value="node"]

--- a/lib/foodcritic/rules/fc095.rb
+++ b/lib/foodcritic/rules/fc095.rb
@@ -1,5 +1,5 @@
 rule "FC095", "Cookbook uses deprecated cloud_v2 ohai plugin data" do
-  tags %w{deprecated chef13}
+  tags %w{deprecated chef15}
 
   recipe do |ast|
     ast.xpath('//aref[vcall/ident/@value="node"]

--- a/lib/foodcritic/rules/fc096.rb
+++ b/lib/foodcritic/rules/fc096.rb
@@ -1,5 +1,5 @@
 rule "FC096", "Cookbook uses deprecated libvirt virtualization ohai data" do
-  tags %w{deprecated chef13}
+  tags %w{deprecated chef14}
 
   recipe do |ast|
     ast.xpath('//aref[aref/vcall/ident/@value="node"]

--- a/lib/foodcritic/rules/fc097.rb
+++ b/lib/foodcritic/rules/fc097.rb
@@ -1,4 +1,4 @@
-rule "FC097", "Deprecated Chef::Mixin::LanguageIncludeAttribute class used" do
+rule "FC097", "Deprecated Chef::Mixin::LanguageIncludeAttribute mixin used" do
   tags %w{chef14 deprecated}
   def lang_include_attrib_mixin(ast)
     # include Chef::Mixin::LanguageIncludeAttribute

--- a/lib/foodcritic/rules/fc098.rb
+++ b/lib/foodcritic/rules/fc098.rb
@@ -1,4 +1,4 @@
-rule "FC098", "Deprecated Chef::Mixin::RecipeDefinitionDSLCore class used" do
+rule "FC098", "Deprecated Chef::Mixin::RecipeDefinitionDSLCore mixin used" do
   tags %w{chef14 deprecated}
   def recipe_def_mixin(ast)
     # include Chef::Mixin::RecipeDefinitionDSLCore

--- a/lib/foodcritic/rules/fc099.rb
+++ b/lib/foodcritic/rules/fc099.rb
@@ -1,4 +1,4 @@
-rule "FC099", "Deprecated Chef::Mixin::LanguageIncludeRecipe class used" do
+rule "FC099", "Deprecated Chef::Mixin::LanguageIncludeRecipe mixin used" do
   tags %w{chef14 deprecated}
   def lang_include_mixin(ast)
     # include Chef::Mixin::LanguageIncludeRecipe

--- a/lib/foodcritic/rules/fc100.rb
+++ b/lib/foodcritic/rules/fc100.rb
@@ -1,4 +1,4 @@
-rule "FC100", "Deprecated Chef::Mixin::Language class used" do
+rule "FC100", "Deprecated Chef::Mixin::Language mixin used" do
   tags %w{chef14 deprecated}
   def lang_mixin(ast)
     # include Chef::Mixin::Language


### PR DESCRIPTION
I was super off when I wrote these. I fixed the tags to be the version
of chef where this will actually break. That's the point of the tags.
It's not when we introduced the deprecation since that makes no sense.

Signed-off-by: Tim Smith <tsmith@chef.io>