### PR TITLE
FC102: Cookbook uses the deprecated Chef::DSL::Recipe::FullDSL class

### DIFF
--- a/lib/foodcritic/rules/fc102.rb
+++ b/lib/foodcritic/rules/fc102.rb
@@ -1,0 +1,11 @@
+rule "FC102", "Deprecated Chef::DSL::Recipe::FullDSL class used" do
+  tags %w{chef14 deprecated}
+  def full_dsl(ast)
+    # include Chef::DSL::Recipe::FullDSL
+    ast.xpath('//const_path_ref/const[@value="FullDSL"]/..//const[@value="Recipe"]/..//const[@value="DSL"]/..//const[@value="Chef"]')
+  end
+  recipe  { |ast| full_dsl(ast) }
+  library { |ast| full_dsl(ast) }
+  resource { |ast| full_dsl(ast) }
+
+end

--- a/spec/functional/fc100_spec.rb
+++ b/spec/functional/fc100_spec.rb
@@ -6,7 +6,7 @@ describe "FC100" do
     it { is_expected.to violate_rule }
   end
 
-  context "with a cookbook with a recipe that includes Chef::Mixin::Languagee" do
+  context "with a cookbook with a recipe that includes Chef::Mixin::Language" do
     recipe_file "include Chef::Mixin::Language"
     it { is_expected.to violate_rule }
   end

--- a/spec/functional/fc102_spec.rb
+++ b/spec/functional/fc102_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "FC102" do
+  context "with a cookbook with a custom resource that includes Chef::DSL::Recipe::FullDSL" do
+    resource_file "include Chef::DSL::Recipe::FullDSL"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that includes Chef::DSL::Recipe::FullDSL" do
+    recipe_file "include Chef::DSL::Recipe::FullDSL"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a library that includes Chef::DSL::Recipe::FullDSL" do
+    library_file "include Chef::DSL::Recipe::FullDSL"
+    it { is_expected.to violate_rule }
+  end
+end


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>