### PR TITLE
Update FC087 to check for all deprecated Chef::Platform methods

### DIFF
--- a/lib/foodcritic/rules/fc087.rb
+++ b/lib/foodcritic/rules/fc087.rb
@@ -1,7 +1,7 @@
-rule "FC087", "Library maps provider with deprecated Chef::Platform.set" do
+rule "FC087", "Library uses deprecated Chef::Platform methods" do
   tags %w{chef13 deprecated}
 
   library do |ast|
-    ast.xpath('//const_path_ref/const[@value="Platform"]/..//const[@value="Chef"]/../../../ident[@value="set"]')
+    ast.xpath('//const_path_ref/const[@value="Platform"]/..//const[@value="Chef"]/../../../ident[@value="set" or @value="provider_for_resource" or @value="find_provider"]')
   end
 end

--- a/spec/functional/fc087_spec.rb
+++ b/spec/functional/fc087_spec.rb
@@ -9,6 +9,20 @@ describe "FC087" do
     it { is_expected.to violate_rule }
   end
 
+  context "with a cookbook with a library that maps providers with Chef::Platform.provider_for_resource" do
+    library_file <<-EOF
+      provider = Chef::Platform.provider_for_resource(resource, :create)
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a library that maps providers with Chef::Platform.provider_for_resource" do
+    library_file <<-EOF
+      provider = Chef::Platform.find_provider("ubuntu", "16.04", resource)
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
   context "with a cookbook with a library that includes Chef::Platform.foo" do
     library_file <<-EOF
     module AuditD

--- a/spec/regression/expected/heartbeat.txt
+++ b/spec/regression/expected/heartbeat.txt
@@ -7,4 +7,5 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
+FC087: Library uses deprecated Chef::Platform methods: ./libraries/default.rb:64
 FC098: Deprecated Chef::Mixin::RecipeDefinitionDSLCore mixin used: ./libraries/default.rb:24

--- a/spec/regression/expected/homebrew.txt
+++ b/spec/regression/expected/homebrew.txt
@@ -7,4 +7,4 @@ FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC074: LWRP should use DSL to define resource's default action: ./resources/tap.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
-FC087: Library maps provider with deprecated Chef::Platform.set: ./libraries/homebrew_package.rb:82
+FC087: Library uses deprecated Chef::Platform methods: ./libraries/homebrew_package.rb:82


### PR DESCRIPTION
There's 3 deprecated methods and we deprecated them all at the same time. FC087 should have included them all from day 1

Signed-off-by: Tim Smith <tsmith@chef.io>