### PR TITLE
Update the tags for FC094 and FC095

### DIFF
--- a/lib/foodcritic/rules/fc094.rb
+++ b/lib/foodcritic/rules/fc094.rb
@@ -1,5 +1,5 @@
 rule "FC094", "Cookbook uses deprecated filesystem2 ohai plugin data" do
-  tags %w{deprecated chef15}
+  tags %w{deprecated chef14}
 
   recipe do |ast|
     ast.xpath('//aref[vcall/ident/@value="node"]

--- a/lib/foodcritic/rules/fc095.rb
+++ b/lib/foodcritic/rules/fc095.rb
@@ -1,5 +1,5 @@
 rule "FC095", "Cookbook uses deprecated cloud_v2 ohai plugin data" do
-  tags %w{deprecated chef15}
+  tags %w{deprecated chef14}
 
   recipe do |ast|
     ast.xpath('//aref[vcall/ident/@value="node"]


### PR DESCRIPTION
We're upping the timeline for deprecating these attributes in Ohai. This
means the rule needs to get updated as well.

Signed-off-by: Tim Smith <tsmith@chef.io>