### PR TITLE
Add FC106: Use the gid property in user instead of group

### DIFF
--- a/lib/foodcritic/rules/fc106.rb
+++ b/lib/foodcritic/rules/fc106.rb
@@ -1,0 +1,8 @@
+rule "FC106", "Use the gid property in user instead of group" do
+  tags %w{correctness}
+  recipe do |ast|
+    find_resources(ast, type: "user").find_all do |user_resource|
+      resource_attribute(user_resource, "group")
+    end
+  end
+end

--- a/spec/functional/fc106_spec.rb
+++ b/spec/functional/fc106_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "FC106" do
+  context "with a cookbook with a recipe that specifies the group in a user resource" do
+    recipe_file <<-EOF
+    user 'bob' do
+      group '1234'
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that specifies the gid in a user resource" do
+    library_file <<-EOF
+    user 'bob' do
+      gid '1234'
+    end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
+end


### PR DESCRIPTION
This is another alias in code where we've create two properties that do the same thing and only cause confusion. Point the users to the actual property.

Signed-off-by: Tim Smith <tsmith@chef.io>