### PR TITLE
Add FC105: Deprecated erl_call resource used

### DIFF
--- a/lib/foodcritic/rules/fc105.rb
+++ b/lib/foodcritic/rules/fc105.rb
@@ -1,0 +1,6 @@
+rule "FC105", "Deprecated erl_call resource used" do
+  tags %w{chef14 deprecated}
+  recipe do |ast|
+    find_resources(ast, type: "erl_call")
+  end
+end

--- a/spec/functional/fc105_spec.rb
+++ b/spec/functional/fc105_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe "FC105" do
+  context "with a cookbook with a custom resource that includes an erl_call resource" do
+    resource_file <<-EOF
+    erl_call 'list names' do
+      code 'net_adm:names().'
+      distributed true
+      node_name 'chef@latte'
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that includes an erl_call resource" do
+    recipe_file <<-EOF
+    erl_call 'list names' do
+      code 'net_adm:names().'
+      distributed true
+      node_name 'chef@latte'
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a library that includes an erl_call resource" do
+    library_file <<-EOF
+    erl_call 'list names' do
+      code 'net_adm:names().'
+      distributed true
+      node_name 'chef@latte'
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+end


### PR DESCRIPTION
It's going away in Chef 14

Signed-off-by: Tim Smith <tsmith@chef.io>