### PR TITLE
Add FC104: Use the :run action in ruby_block instead of :create

### DIFF
--- a/lib/foodcritic/rules/fc104.rb
+++ b/lib/foodcritic/rules/fc104.rb
@@ -1,0 +1,8 @@
+rule "FC104", "Use the :run action in ruby_block instead of :create" do
+  tags %w{correctness}
+  recipe do |ast|
+    find_resources(ast, type: "ruby_block").find_all do |ruby_resource|
+      resource_attribute(ruby_resource, "action") == :create
+    end
+  end
+end

--- a/lib/foodcritic/rules/fc104.rb
+++ b/lib/foodcritic/rules/fc104.rb
@@ -1,8 +1,18 @@
 rule "FC104", "Use the :run action in ruby_block instead of :create" do
   tags %w{correctness}
   recipe do |ast|
-    find_resources(ast, type: "ruby_block").find_all do |ruby_resource|
-      resource_attribute(ruby_resource, "action") == :create
+    matches = []
+    find_resources(ast).each do |resource|
+      # if it's a ruby_block check for the :create action
+      if ast.xpath('//method_add_block[command/ident[@value="ruby_block"]]')
+        matches << resource if resource_attribute(resource, "action") == :create
+      end
+
+      # no matter what check notification
+      notifications(resource).any? do |notification|
+        matches << resource if notification[:resource_type] == :ruby_block && notification[:action] == :create
+      end
     end
+    matches
   end
 end

--- a/spec/functional/fc104_spec.rb
+++ b/spec/functional/fc104_spec.rb
@@ -24,4 +24,22 @@ describe "FC104" do
     EOF
     it { is_expected.to_not violate_rule }
   end
+
+  context "with a cookbook with a recipe that notifies :create on a ruby_block" do
+    library_file <<-EOF
+    file 'foo' do
+      notifies :create, 'ruby_block[bar]', :delayed
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that notifies :run on a ruby_block" do
+    library_file <<-EOF
+    file 'foo' do
+      notifies :run, 'ruby_block[bar]', :delayed
+    end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
 end

--- a/spec/functional/fc104_spec.rb
+++ b/spec/functional/fc104_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+describe "FC104" do
+  context "with a cookbook with a recipe where ruby_block specifies a create action" do
+    recipe_file <<-EOF
+    ruby_block 'puts' do
+      block do
+        puts "test test test"
+      end
+      action :create
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe where ruby_block specifies a run action" do
+    library_file <<-EOF
+    ruby_block 'puts' do
+      block do
+        puts "test test test"
+      end
+      action :run
+    end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
+end


### PR DESCRIPTION
We have an alias here to prevent people from using :create. Most people on the supermarket are doing the right thing. The create action doesn't reflect what's actually happening with the resource and we should remove it from the docs entirely.

Signed-off-by: Tim Smith <tsmith@chef.io>