### PR TITLE
Add FC107: Resource uses epic_fail instead of ignore_failure

### DIFF
--- a/lib/foodcritic/rules/fc107.rb
+++ b/lib/foodcritic/rules/fc107.rb
@@ -1,0 +1,6 @@
+rule "FC107", "Resource uses epic_fail instead of ignore_failure" do
+  tags %w{deprecated chef14}
+  recipe do |ast|
+    find_resources(ast).xpath('(.//command|.//fcall)[ident/@value="epic_fail"]')
+  end
+end

--- a/spec/functional/fc107_spec.rb
+++ b/spec/functional/fc107_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe "FC107" do
+  context "with a cookbook with a recipe that uses uses epic_fail in a resource" do
+    recipe_file <<-EOF
+    chocolatey_package 'name' do
+      epic_fail true
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that uses uses ignore_failure in a resource" do
+    library_file <<-EOF
+    chocolatey_package 'name' do
+      action :install
+      ignore_failure true
+    end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
+end


### PR DESCRIPTION
Yet another alias this time from WAY back in the early days of Chef. I was removing these references in my Chef 0.9 code. We don't even document this anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>