### PR TITLE
Add FC108: Resource should not define a property named 'name'

### DIFF
--- a/lib/foodcritic/rules/fc108.rb
+++ b/lib/foodcritic/rules/fc108.rb
@@ -1,0 +1,12 @@
+rule "FC108", "Resource should not define a property named 'name'" do
+  tags %w{correctness}
+  resource do |ast|
+    # Make sure we're in a custom resource not an LWRP
+    if ast.xpath("//command/ident/@value='action'")
+      # command has a child of type ident with a value of "property". That tells us
+      # we're in a property. Quite a ways desecendant from that is another ident
+      # with value of "name"
+      ast.xpath("//command[ident/@value='property' and descendant::ident/@value='name']")
+    end
+  end
+end

--- a/lib/foodcritic/rules/fc108.rb
+++ b/lib/foodcritic/rules/fc108.rb
@@ -6,7 +6,7 @@ rule "FC108", "Resource should not define a property named 'name'" do
       # command has a child of type ident with a value of "property". That tells us
       # we're in a property. Quite a ways desecendant from that is another ident
       # with value of "name"
-      ast.xpath("//command[ident/@value='property' and descendant::ident/@value='name']")
+      ast.xpath("//command[ident/@value='property' and descendant::symbol_literal/symbol/ident/@value='name']")
     end
   end
 end

--- a/spec/functional/fc108_spec.rb
+++ b/spec/functional/fc108_spec.rb
@@ -20,4 +20,14 @@ describe "FC108" do
     EOF
     it { is_expected.to_not violate_rule }
   end
+
+  context "with a cookbook with a custom resource where a property contains a name variable" do
+    recipe_file <<-EOF
+    property :home, String, default: lazy { ::File.join('/home/', name) }
+
+    action :create do
+    end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
 end

--- a/spec/functional/fc108_spec.rb
+++ b/spec/functional/fc108_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "FC108" do
+  context "with a cookbook with a custom resource that defines a name property" do
+    resource_file <<-EOF
+    property :name, String, name_property: true
+
+        action :create do
+        end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a custom resource that does not defines a name property" do
+    recipe_file <<-EOF
+    property :not_name, String, name_property: true
+
+    action :create do
+    end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
+end

--- a/spec/functional/fc108_spec.rb
+++ b/spec/functional/fc108_spec.rb
@@ -30,4 +30,14 @@ describe "FC108" do
     EOF
     it { is_expected.to_not violate_rule }
   end
+
+  context "with a cookbook with a custom resource where a property contains a name symbol" do
+    recipe_file <<-EOF
+    property :foo, Symbol, default: :name
+
+    action :create do
+    end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
 end


### PR DESCRIPTION
There's no need to redefine the name property in custom resources. It's all over the place in custom resource code and I see it in PRs for our cookbooks all the time. People think they have to do this.

Signed-off-by: Tim Smith <tsmith@chef.io>