### PR TITLE
Add FC106: Use the plist_hash property in user instead of hash

### DIFF
--- a/lib/foodcritic/rules/fc106.rb
+++ b/lib/foodcritic/rules/fc106.rb
@@ -1,0 +1,8 @@
+rule "FC106", "Use the plist_hash property in user instead of hash" do
+  tags %w{deprecation chef13}
+  recipe do |ast|
+    find_resources(ast, type: "launchd").find_all do |launchd_resource|
+      resource_attribute(launchd_resource, "hash")
+    end
+  end
+end

--- a/lib/foodcritic/rules/fc106.rb
+++ b/lib/foodcritic/rules/fc106.rb
@@ -1,4 +1,4 @@
-rule "FC106", "Use the plist_hash property in user instead of hash" do
+rule "FC106", "Use the plist_hash property in launchd instead of hash" do
   tags %w{deprecation chef13}
   recipe do |ast|
     find_resources(ast, type: "launchd").find_all do |launchd_resource|

--- a/spec/functional/fc106_spec.rb
+++ b/spec/functional/fc106_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "FC106" do
+  context "with a cookbook with a recipe that uses hash in a launchd resource" do
+    recipe_file <<-EOF
+    launchd 'foo' do
+      hash {}
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a recipe that uses plist_hash in a launchd  resource" do
+    library_file <<-EOF
+    launchd 'foo' do
+      plist_hash {}
+    end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
+end


### PR DESCRIPTION
We changed hash to plist_hash in chef 13

Signed-off-by: Tim Smith <tsmith@chef.io>