### PR TITLE
Add FC109: Package resources should not specify the provider

### DIFF
--- a/lib/foodcritic/rules/fc109.rb
+++ b/lib/foodcritic/rules/fc109.rb
@@ -1,0 +1,8 @@
+rule "FC109", "Package resources should not specify the provider" do
+  tags %w{correctness}
+  recipe do |ast|
+    find_resources(ast, type: "package").find_all do |package_resources|
+      resource_attribute(package_resources, "provider")
+    end
+  end
+end

--- a/spec/functional/fc109_spec.rb
+++ b/spec/functional/fc109_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe "FC109" do
+  context "with a cookbook with a package resource that defines a provider" do
+    resource_file <<-EOF
+    package 'foo' do
+      provider Chef::Provider::Package::Rpm
+      action :install
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a package resource that doesn't define a provider" do
+    resource_file <<-EOF
+    package 'foo' do
+      action :install
+    end
+    EOF
+    it { is_expected.to_not violate_rule }
+  end
+end


### PR DESCRIPTION
Lamont noted that we shouldn't be doing this and it fundamentally doesn't work.

Signed-off-by: Tim Smith <tsmith@chef.io>