### PR TITLE
Don't require a space before the # in an ignore comment.

### DIFF
--- a/features/ignore_via_line_comments.feature
+++ b/features/ignore_via_line_comments.feature
@@ -46,7 +46,7 @@ Feature: Ignoring rules on per line basis
   Examples:
     | comment         | warnings    |
     |                 | FC002,FC039 |
-    | # ~FC002,~FC007 | FC002       |
+    | # ~FC002,~FC007 | FC039       |
     | # ~FC002,~FC039 |             |
     | # ~FC002        | FC039       |
 

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -183,7 +183,7 @@ module FoodCritic
     end
 
     def ignore_line_match?(line, rule)
-      ignores = line.to_s[/#\s*(.*)/, 1]
+      ignores = line.to_s[/.*#\s*(.*)/, 1]
       if ignores && ignores.include?("~")
         !rule.matches_tags?(ignores.split(/[ ,]/))
       else

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -183,7 +183,7 @@ module FoodCritic
     end
 
     def ignore_line_match?(line, rule)
-      ignores = line.to_s[/\s+#\s*(.*)/, 1]
+      ignores = line.to_s[/#\s*(.*)/, 1]
       if ignores && ignores.include?("~")
         !rule.matches_tags?(ignores.split(/[ ,]/))
       else

--- a/spec/functional/fc059_spec.rb
+++ b/spec/functional/fc059_spec.rb
@@ -24,4 +24,16 @@ describe "FC059" do
     EOF
     it { is_expected.not_to violate_rule }
   end
+
+  context "with a cookbook ignoring the rule" do
+    provider_file <<~EOF
+    # ~FC059
+    action :create do
+      template "/etc/something.conf" do
+        notifies :restart, "service[something]"
+      end
+    end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
 end

--- a/spec/functional/fc059_spec.rb
+++ b/spec/functional/fc059_spec.rb
@@ -26,7 +26,7 @@ describe "FC059" do
   end
 
   context "with a cookbook ignoring the rule" do
-    provider_file <<~EOF
+    provider_file <<-EOF.gsub(/^    /, '') # When we drop 2.2 support, this can use <<~EOF.
     # ~FC059
     action :create do
       template "/etc/something.conf" do

--- a/spec/functional/fc059_spec.rb
+++ b/spec/functional/fc059_spec.rb
@@ -26,7 +26,7 @@ describe "FC059" do
   end
 
   context "with a cookbook ignoring the rule" do
-    provider_file <<-EOF.gsub(/^    /, '') # When we drop 2.2 support, this can use <<~EOF.
+    provider_file <<-EOF.gsub(/^    /, "") # When we drop 2.2 support, this can use <<~EOF.
     # ~FC059
     action :create do
       template "/etc/something.conf" do


### PR DESCRIPTION
This is important for file-level ignores which go on line 1 for now. We should have a better comment system for file-level ignores but this is a stop-gap at least.