### PR TITLE
Allow search for multiple resource types in the find_resources api method

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -191,7 +191,7 @@ module FoodCritic
       return [] unless ast.respond_to?(:xpath)
       scope_type = ""
       unless options[:type] == :any
-        type_array =  Array(options[:type]).map! { |x| "@value='#{x}'" }
+        type_array =  Array(options[:type]).map { |x| "@value='#{x}'" }
         scope_type = "[#{type_array.join(' or ')}]"
       end
 

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -179,17 +179,21 @@ module FoodCritic
     # These are equivalent:
     #
     #     find_resources(ast)
-    #     find_resources(ast, :type => :any)
+    #     find_resources(ast, type: :any)
     #
-    # Restrict to a specific type of resource:
+    # Restrict to a specific type of resource(s):
     #
-    #     find_resources(ast, :type => :service)
+    #     find_resources(ast, type: 'service')
+    #     find_resources(ast, type: %w(service file))
     #
     def find_resources(ast, options = {})
       options = { type: :any }.merge!(options)
       return [] unless ast.respond_to?(:xpath)
       scope_type = ""
-      scope_type = "[@value='#{options[:type]}']" unless options[:type] == :any
+      unless options[:type] == :any
+        type_array =  Array(options[:type]).map! { |x| "@value='#{x}'" }
+        scope_type = "[#{type_array.join(' or ')}]"
+      end
 
       # TODO: Include nested resources (provider actions)
       no_actions = "[command/ident/@value != 'action']"

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -402,7 +402,11 @@ describe FoodCritic::Api do
     it "returns empty unless the ast supports XPath" do
       expect(api.find_resources(nil)).to be_empty
     end
-    it "restricts by resource type when provided" do
+    it "restricts by resource type when provided an array" do
+      expect(ast).to receive(:xpath).with("//method_add_block[command/ident[@value='file' or @value='template']][command/ident/@value != 'action']").and_return(["method_add_block"])
+      api.find_resources(ast, :type => %w{file template})
+    end
+    it "restricts by resource type when provided a string" do
       expect(ast).to receive(:xpath).with("//method_add_block[command/ident[@value='file']][command/ident/@value != 'action']").and_return(["method_add_block"])
       api.find_resources(ast, :type => "file")
     end


### PR DESCRIPTION
Type can still be a string, but it can also be an array of resource types. I was kinda surprised this wasn't already a thing here.

Signed-off-by: Tim Smith <tsmith@chef.io>