### PR TITLE
Add FC110: Script resources should use 'code' property not 'command' property

### DIFF
--- a/lib/foodcritic/rules/fc110.rb
+++ b/lib/foodcritic/rules/fc110.rb
@@ -1,0 +1,18 @@
+rule "FC110", "Script resources should use 'code' property not 'command' property" do
+  tags %w{deprecation chef13}
+  recipe do |ast|
+    script_resources = %w{ bash
+                           ksh
+                           cash
+                           script
+                           batch
+                           perl
+                           python
+                           ruby
+                           windows_script
+                         }
+    find_resources(ast, type: script_resources).find_all do |resources|
+      resource_attribute(resources, "command")
+    end
+  end
+end

--- a/spec/functional/fc110_spec.rb
+++ b/spec/functional/fc110_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "FC110" do
+  context "with a cookbook with a script resource that uses command" do
+    resource_file <<-EOF
+    bash 'foo' do
+      command 'cat /etc/passwd'
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a script resource that uses code" do
+    resource_file <<-EOF
+    bash 'foo' do
+      code 'cat /etc/passwd'
+    end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
We hard fail in Chef 13 when command is specified. It's not a very
common thing, but there are few cookbooks doing it on the Supermarket.

Signed-off-by: Tim Smith <tsmith@chef.io>