### PR TITLE
Add FC112: Resource using deprecated dsl_name method

### DIFF
--- a/lib/foodcritic/rules/fc112.rb
+++ b/lib/foodcritic/rules/fc112.rb
@@ -1,0 +1,6 @@
+rule "FC112", "Resource using deprecated dsl_name method" do
+  tags %w{deprecation chef13}
+  recipe do |ast|
+    ast.xpath("//call/ident[@value='dsl_name']")
+  end
+end

--- a/spec/functional/fc112_spec.rb
+++ b/spec/functional/fc112_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe "FC112" do
+  context "with a cookbook with a resource that uses dsl_name" do
+    library_file <<-EOF
+    my_resource = MyResource.dsl_name
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a resource that uses resource_name" do
+    library_file <<-EOF
+    my_resource = MyResource.resource_name
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
This catches a pretty obscure Chef 13 deprecation. I'm not entirely sure anyone ever used this, but it fits our goal of getting all the Chef 13 deprecations into Foodcritic when possible.

Signed-off-by: Tim Smith <tsmith@chef.io>