### PR TITLE
Add FC114: Cookbook uses legacy Ohai config syntax

### DIFF
--- a/lib/foodcritic/rules/fc114.rb
+++ b/lib/foodcritic/rules/fc114.rb
@@ -1,0 +1,30 @@
+rule "FC114", "Cookbook uses legacy Ohai config syntax" do
+  tags %w{chef13 deprecated}
+  recipe do |ast|
+    # <aref value="aref"> <-- if assigning this will be aref_field
+    #   <const_path_ref value="const_path_ref">
+    #     <var_ref value="var_ref">
+    #       <const value="Ohai">
+    #         <pos line="3" column="0"/>
+    #       </const>
+    #     </var_ref>
+    #     <const value="Config">
+    #       <pos line="3" column="6"/>
+    #     </const>
+    #   </const_path_ref>
+    #   <args_add_block value="false">
+    #     <args_add value="args_add">
+    #       <args_new value="args_new"/>
+    #       <symbol_literal value="symbol_literal">
+    #         <symbol value="symbol">
+    #           <ident value="something">
+    #             <pos line="3" column="14"/>
+    #           </ident>
+    #         </symbol>
+    #       </symbol_literal>
+    #     </args_add>
+    #   </args_add_block>
+    # </aref>
+    ast.xpath('//*[self::aref or self::aref_field][const_path_ref/const/@value="Config"][const_path_ref/var_ref/const/@value="Ohai"][args_add_block/args_add/symbol_literal/symbol]')
+  end
+end

--- a/lib/foodcritic/rules/fc114.rb
+++ b/lib/foodcritic/rules/fc114.rb
@@ -1,6 +1,8 @@
 rule "FC114", "Cookbook uses legacy Ohai config syntax" do
   tags %w{chef13 deprecated}
   recipe do |ast|
+    # Ohai::Config[:something]
+    #
     # <aref value="aref"> <-- if assigning this will be aref_field
     #   <const_path_ref value="const_path_ref">
     #     <var_ref value="var_ref">

--- a/spec/functional/fc114_spec.rb
+++ b/spec/functional/fc114_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe "FC114" do
+  context "with a cookbook that uses the legacy Ohai config" do
+    library_file <<-EOF
+    Ohai::Config[:something]
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook that sets the legacy Ohai config value" do
+    library_file <<-EOF
+    Ohai::Config[:something] = 'something'
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook that uses the new full form Ohai config" do
+    library_file <<-EOF
+    Ohai::Config.ohai[:something] = 'something'
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+
+  context "with a cookbook that uses the new short form Ohai config" do
+    library_file <<-EOF
+    Ohai.config[:something] = 'something'
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+end

--- a/spec/regression/expected/ohai.txt
+++ b/spec/regression/expected/ohai.txt
@@ -5,3 +5,5 @@ FC067: Ensure at least one platform supported in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC072: Metadata should not contain "attribute" keyword: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
+FC114: Cookbook uses legacy Ohai config syntax: ./recipes/default.rb:20
+FC114: Cookbook uses legacy Ohai config syntax: ./recipes/default.rb:21


### PR DESCRIPTION
We deprecated the legacy config syntax in Chef 13

Signed-off-by: Tim Smith <tsmith@chef.io>