### PR TITLE
Add FC111: search using deprecated sort flag

### DIFF
--- a/lib/foodcritic/rules/fc111.rb
+++ b/lib/foodcritic/rules/fc111.rb
@@ -1,0 +1,7 @@
+rule "FC111", "search using deprecated sort flag" do
+  tags %w{deprecation chef13}
+  recipe do |ast|
+    # search(:node, 'role:web', :sort => true)
+    ast.xpath("//method_add_arg[fcall/ident/@value='search'][arg_paren/args_add_block/args_add/bare_assoc_hash/assoc_new/symbol/ident/@value = 'sort']")
+  end
+end

--- a/spec/functional/fc111_spec.rb
+++ b/spec/functional/fc111_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe "FC111" do
+  context "with a cookbook with a search that uses the deprecated sort flag" do
+    resource_file <<-EOF
+    search(:node, 'role:web', :sort => true)
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a cookbook with a search that does not use sort" do
+    resource_file <<-EOF
+    search(:node, 'role:web')
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
Nothing on the Supermarket uses this and it's a pretty rare edge case,
but the implementation is dead simple and this is another thing we had
listed in our breaking (arguable) changes for Chef 13.

Signed-off-by: Tim Smith <tsmith@chef.io>