### PR TITLE
Remove support for Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.5
-  - 2.4.2
+  - 2.3.6
+  - 2.4.3
 bundler_args: --jobs 3 --retry 3
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.2.8
   - 2.3.5
   - 2.4.2
 bundler_args: --jobs 3 --retry 3

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Foodcritic site at <http://foodcritic.io/> contains documentation for each o
 
 ## Requirements
 
-- Ruby 2.2.2+
+- Ruby 2.3+
 
 ## Building Foodcritic
 

--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://foodcritic.io"
   s.license = "MIT"
   s.executables << "foodcritic"
-  s.required_ruby_version = ">= 2.2.2"
+  s.required_ruby_version = ">= 2.3"
 
   s.files = Dir["chef_dsl_metadata/*.json"] +
     Dir["lib/**/*.rb"] +


### PR DESCRIPTION
Ruby 2.2 goes EOL 3/18