### PR TITLE
Add FC115 to detect required name_properties

### DIFF
--- a/lib/foodcritic/rules/fc115.rb
+++ b/lib/foodcritic/rules/fc115.rb
@@ -1,0 +1,9 @@
+rule "FC115", "Custom resource contains a name_property that is required" do
+  tags %w{correctness}
+  recipe do |ast|
+    ast.xpath("//command[ident/@value='property'
+      and descendant::bare_assoc_hash/assoc_new[label/@value='name_property:' and kw/@value='true']
+      and descendant::bare_assoc_hash/assoc_new[label/@value='required:' and kw/@value='true']
+      and descendant::symbol_literal/symbol/ident/@value!='name']")
+  end
+end

--- a/spec/functional/fc115_spec.rb
+++ b/spec/functional/fc115_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe "FC115" do
+  context "with a resource that requires a name property" do
+    resource_file <<-EOF
+    property :url, String, name_property: true, required: true
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a resource that explicitly doesn't required a name property" do
+    resource_file <<-EOF
+    property :url, String, name_property: true, required: false
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+
+  context "with a resource that requires a name property with the name of 'name'" do
+    resource_file <<-EOF
+    property :name, String, name_property: true, required: true
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
There's no point in making something a name property if you also require it. It'll never get the default value from the resource name that way.

Here's the offenders:

```
FC115: Custom resource contains a name_property that is required: ./alteryx-server/resources/license.rb:1
FC115: Custom resource contains a name_property that is required: ./docker/libraries/docker_service_base.rb:20
FC115: Custom resource contains a name_property that is required: ./ec2cron/resources/profile.rb:3
FC115: Custom resource contains a name_property that is required: ./httpd/libraries/httpd_config.rb:3
FC115: Custom resource contains a name_property that is required: ./httpd/libraries/httpd_module.rb:9
FC115: Custom resource contains a name_property that is required: ./ignite-openfire/resources/plugin.rb:5
FC115: Custom resource contains a name_property that is required: ./ilo/libraries/account_service.rb:20
FC115: Custom resource contains a name_property that is required: ./ilo/libraries/user.rb:20
FC115: Custom resource contains a name_property that is required: ./karaf/resources/karaf_bundle.rb:4
FC115: Custom resource contains a name_property that is required: ./karaf/resources/karaf_feature.rb:4
FC115: Custom resource contains a name_property that is required: ./karaf/resources/karaf_feature_repository.rb:4
FC115: Custom resource contains a name_property that is required: ./karaf/resources/karaf_group.rb:4
FC115: Custom resource contains a name_property that is required: ./karaf/resources/karaf_user.rb:4
FC115: Custom resource contains a name_property that is required: ./libarchive/resources/file.rb:8
FC115: Custom resource contains a name_property that is required: ./lineinfile/resources/lineinfile.rb:8
FC115: Custom resource contains a name_property that is required: ./locustio/resources/node.rb:2
FC115: Custom resource contains a name_property that is required: ./nfs4acl/resources/nfs4_setfacl.rb:23
FC115: Custom resource contains a name_property that is required: ./remote-exec/resources/remote_execute.rb:22
FC115: Custom resource contains a name_property that is required: ./windows/resources/certificate.rb:23
FC115: Custom resource contains a name_property that is required: ./windows/resources/certificate_binding.rb:25
FC115: Custom resource contains a name_property that is required: ./windows/resources/http_acl.rb:24
FC115: Custom resource contains a name_property that is required: ./windows/resources/printer.rb:25
```

Signed-off-by: Tim Smith <tsmith@chef.io>