### PR TITLE
Add FC118: Detect using name_attribute instead of name_property

### DIFF
--- a/lib/foodcritic/rules/fc118.rb
+++ b/lib/foodcritic/rules/fc118.rb
@@ -1,0 +1,7 @@
+rule "FC118", "Resource property setting name_attribute vs. name_property" do
+  tags %w{correctness}
+  recipe do |ast|
+    ast.xpath("//command[ident/@value='property'
+      and descendant::bare_assoc_hash/assoc_new/label/@value='name_attribute:']")
+  end
+end

--- a/spec/functional/fc118_spec.rb
+++ b/spec/functional/fc118_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe "FC118" do
+  context "with a property that sets the name_attribute value" do
+    resource_file <<-EOF
+    property :url, String, name_attribute: true
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a property that sets the name_property value" do
+    resource_file <<-EOF
+    property :url, String, name_property: true
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
If we're using properties we should be using name_property not name_attribute here.  Here's the list of offenders from the Supermarket:

```
FC118: Resource property setting name_attribute vs. name_property: ./apparmor/resources/policy.rb:19
FC118: Resource property setting name_attribute vs. name_property: ./appveyorapi/resources/deploy.rb:21
FC118: Resource property setting name_attribute vs. name_property: ./apt/resources/preference.rb:20
FC118: Resource property setting name_attribute vs. name_property: ./baragon/resources/agent.rb:22
FC118: Resource property setting name_attribute vs. name_property: ./chef-ingredient/resources/chef_ingredient.rb:23
FC118: Resource property setting name_attribute vs. name_property: ./chef_slack/resources/notify.rb:3
FC118: Resource property setting name_attribute vs. name_property: ./common_attrs/resources/common_environment.rb:21
FC118: Resource property setting name_attribute vs. name_property: ./common_attrs/resources/common_namespace.rb:21
FC118: Resource property setting name_attribute vs. name_property: ./common_attrs/resources/common_secret.rb:8
FC118: Resource property setting name_attribute vs. name_property: ./container/resources/container_user.rb:2
FC118: Resource property setting name_attribute vs. name_property: ./djbdns/resources/rr.rb:23
FC118: Resource property setting name_attribute vs. name_property: ./ec2dnsserver/resources/zone.rb:23
FC118: Resource property setting name_attribute vs. name_property: ./git/resources/config.rb:1
FC118: Resource property setting name_attribute vs. name_property: ./iis-lb/resources/farm.rb:1
FC118: Resource property setting name_attribute vs. name_property: ./iis-lb/resources/server.rb:1
FC118: Resource property setting name_attribute vs. name_property: ./iis/resources/config.rb:23
FC118: Resource property setting name_attribute vs. name_property: ./inifile_chef_gem/resources/default.rb:1
FC118: Resource property setting name_attribute vs. name_property: ./iptables/resources/rule.rb:20
FC118: Resource property setting name_attribute vs. name_property: ./memcached/resources/instance_systemd.rb:39
FC118: Resource property setting name_attribute vs. name_property: ./memcached/resources/instance_sysv_init.rb:33
FC118: Resource property setting name_attribute vs. name_property: ./mongodb3-objects/resources/mongodb_collection_index.rb:22
FC118: Resource property setting name_attribute vs. name_property: ./mongodb3-objects/resources/mongodb_shard.rb:22
FC118: Resource property setting name_attribute vs. name_property: ./mongodb3-objects/resources/mongodb_sharding_collection.rb:22
FC118: Resource property setting name_attribute vs. name_property: ./mongodb3-objects/resources/mongodb_sharding_database.rb:22
FC118: Resource property setting name_attribute vs. name_property: ./motd-tail/resources/motd_tail.rb:25
FC118: Resource property setting name_attribute vs. name_property: ./msys2/resources/execute.rb:12
FC118: Resource property setting name_attribute vs. name_property: ./msys2/resources/package.rb:12
FC118: Resource property setting name_attribute vs. name_property: ./mule/resources/centos.rb:4
FC118: Resource property setting name_attribute vs. name_property: ./mule/resources/ubuntu.rb:3
FC118: Resource property setting name_attribute vs. name_property: ./mysql-replication/resources/mysql_master.rb:19
FC118: Resource property setting name_attribute vs. name_property: ./mysql-replication/resources/mysql_slave.rb:19
FC118: Resource property setting name_attribute vs. name_property: ./mysql2_chef_gem/resources/mysql2_chef_gem_mariadb.rb:1
FC118: Resource property setting name_attribute vs. name_property: ./mysql2_chef_gem/resources/mysql2_chef_gem_mysql.rb:1
FC118: Resource property setting name_attribute vs. name_property: ./nuget/resources/sources.rb:25
FC118: Resource property setting name_attribute vs. name_property: ./php_wrapper/resources/php_config.rb:9
FC118: Resource property setting name_attribute vs. name_property: ./rsyslog/resources/file_input.rb:19
FC118: Resource property setting name_attribute vs. name_property: ./rubyzip/libraries/zipfile.rb:18
FC118: Resource property setting name_attribute vs. name_property: ./s3_dir/resources/default.rb:3
FC118: Resource property setting name_attribute vs. name_property: ./simple_passenger/resources/app.rb:3
FC118: Resource property setting name_attribute vs. name_property: ./swap/resources/file.rb:18
FC118: Resource property setting name_attribute vs. name_property: ./trusted_certificate/resources/trusted_certificate.rb:20
FC118: Resource property setting name_attribute vs. name_property: ./varnish/resources/varnish_config.rb:5
FC118: Resource property setting name_attribute vs. name_property: ./varnish/resources/varnish_log.rb:5
FC118: Resource property setting name_attribute vs. name_property: ./varnish/resources/vcl_file.rb:5
FC118: Resource property setting name_attribute vs. name_property: ./varnish/resources/vcl_template.rb:5
FC118: Resource property setting name_attribute vs. name_property: ./win_cluster/resources/server.rb:1
FC118: Resource property setting name_attribute vs. name_property: ./windows/resources/feature_powershell.rb:7
FC118: Resource property setting name_attribute vs. name_property: ./windows/resources/feature_servermanagercmd.rb:21
FC118: Resource property setting name_attribute vs. name_property: ./windows/resources/printer_port.rb:25
FC118: Resource property setting name_attribute vs. name_property: ./zookeeper/resources/config.rb:21
FC118: Resource property setting name_attribute vs. name_property: ./zookeeper/resources/default.rb:22
FC118: Resource property setting name_attribute vs. name_property: ./zookeeper/resources/node.rb:22
```
Signed-off-by: Tim Smith <tsmith@chef.io>