### PR TITLE
Add FC119: windows_task :change action no longer exists in Chef 13

### DIFF
--- a/lib/foodcritic/rules/fc119.rb
+++ b/lib/foodcritic/rules/fc119.rb
@@ -1,0 +1,16 @@
+rule "FC119", "windows_task :change action no longer exists in Chef 13" do
+  tags %w{deprecation chef13}
+  recipe do |ast|
+    matches = []
+    find_resources(ast).each do |resource|
+      # if it's a ruby_block check for the :create action
+      matches << resource if resource_attribute(resource, "action") == :change && resource_type(resource) == "windows_task"
+
+      # no matter what check notification
+      notifications(resource).any? do |notification|
+        matches << resource if notification[:resource_type] == :windows_task && notification[:action] == :change
+      end
+    end
+    matches
+  end
+end

--- a/spec/functional/fc119_spec.rb
+++ b/spec/functional/fc119_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+describe "FC119" do
+  context "with a windows_task resource that uses the :change action" do
+    recipe_file <<-EOF
+    windows_task 'chef-client' do
+      user 'Administrator'
+      password 'N3wPassW0Rd'
+      command 'chef-client'
+      action :change
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a windows_task resource that uses the :create action" do
+    recipe_file <<-EOF
+    windows_task 'chef-client' do
+      user 'Administrator'
+      password 'N3wPassW0Rd'
+      command 'chef-client'
+      action :create
+    end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
We didn't port the :change action over in Chef 13. It was just a dirty hack for not supporting true idempotency in the cookbook.

There's just 1 violation on the Supermarket:
```
FC119: windows_task :change action no longer exists in Chef 13: ./ad-join/resources/domain_join.rb:69
```

Signed-off-by: Tim Smith <tsmith@chef.io>