### PR TITLE
Add FC117: Do not use kind_of in custom resource properties

### DIFF
--- a/lib/foodcritic/rules/fc117.rb
+++ b/lib/foodcritic/rules/fc117.rb
@@ -1,0 +1,9 @@
+rule "FC117", "Do not use kind_of in custom resource properties" do
+  tags %w{correctness}
+  resource do |ast|
+    # Make sure we're in a custom resource not an LWRP
+    if ast.xpath("//command/ident/@value='action'")
+      ast.xpath("//command[ident/@value='property'][args_add_block//label/@value='kind_of:']")
+    end
+  end
+end

--- a/spec/functional/fc117_spec.rb
+++ b/spec/functional/fc117_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "FC117" do
+  context "with a custom resource that includes kind_of in the property definition" do
+    resource_file <<-EOF
+    property :name, kind_of: String, name_property: true
+
+        action :create do
+        end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a custom resource that does not include kind_of in the property definition" do
+    resource_file <<-EOF
+    property :name, String, name_property: true
+
+        action :create do
+        end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
Turns out kind_of and a straight Ruby type in a custom resource aren't actually the same code path. We should get people off of kind_of when they're writing custom resources since some day we'll probably want to kill off the old code.

Signed-off-by: Tim Smith <tsmith@chef.io>