### PR TITLE
Fixup notification action detect and fail FC037 if they're strings

### DIFF
--- a/lib/foodcritic/notifications.rb
+++ b/lib/foodcritic/notifications.rb
@@ -132,7 +132,7 @@ module FoodCritic
     def notification_action(notify)
       is_variable = true unless notify.xpath("args_add_block/args_add//args_add[aref or vcall or call or var_ref]").empty?
       string_val = notify.xpath("descendant::args_add/string_literal/string_add/tstring_content/@value").first
-      symbol_val = notify.xpath('descendant::symbol[1]/ident/@value |
+      symbol_val = notify.xpath('descendant::args_add/args_add//symbol/ident/@value |
         descendant::dyna_symbol[1]/xstring_add/tstring_content/@value').first
 
       # 1) return a nil if the action is a variable like node['foo']['bar']

--- a/lib/foodcritic/notifications.rb
+++ b/lib/foodcritic/notifications.rb
@@ -126,10 +126,21 @@ module FoodCritic
       resource_hash_references(notify).empty?
     end
 
+    # return the notification action as either a symbol or string or nil if it's a variable.
+    # Yes you can notify an action as a string but it's wrong and we want to return it as
+    # a string so we can tell people not to do that.
     def notification_action(notify)
-      notify.xpath('descendant::symbol[1]/ident/@value |
-        descendant::dyna_symbol[1]/xstring_add/
-        tstring_content/@value').first.to_s.to_sym
+      is_variable = true unless notify.xpath("args_add_block/args_add//args_add[aref or vcall or call or var_ref]").empty?
+      string_val = notify.xpath("descendant::args_add/string_literal/string_add/tstring_content/@value").first
+      symbol_val = notify.xpath('descendant::symbol[1]/ident/@value |
+        descendant::dyna_symbol[1]/xstring_add/tstring_content/@value').first
+
+      # 1) return a nil if the action is a variable like node['foo']['bar']
+      # 2) return the symbol if it exists
+      # 3) return the string since we're positive that we're not a symbol or variable
+      return nil if is_variable
+      return symbol_val.value.to_sym unless symbol_val.nil?
+      string_val.value
     end
 
     def notification_nodes(ast, &block)

--- a/lib/foodcritic/rules/fc037.rb
+++ b/lib/foodcritic/rules/fc037.rb
@@ -7,7 +7,8 @@ rule "FC037", "Invalid notification action" do
                when :notifies then n[:resource_type]
                when :subscribes then resource_type(resource).to_sym
                end
-        n[:action].size > 0 && !resource_action?(type, n[:action])
+        # either the action is a string or it's not nil (means it was a variable) and not valid
+        n[:action].is_a?(String) || (!n[:action].nil? && !resource_action?(type, n[:action]))
       end
     end
   end

--- a/spec/functional/fc037_spec.rb
+++ b/spec/functional/fc037_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+describe "FC037" do
+  context "with a resource that notifies using an action that is a string" do
+    recipe_file <<-EOF
+    file '/tmp/b.txt' do
+      content 'content'
+      notifies 'restart', 'service[httpd]', :delayed
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a resource that notifies using an action as a symbol" do
+    recipe_file <<-EOF
+    file '/tmp/a.txt' do
+      content 'content'
+      notifies :restart, 'service[httpd]', :delayed
+    end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+
+  context "with a resource that notifies using an action that is an attribute" do
+    recipe_file <<-EOF
+    file '/tmp/a.txt' do
+      content 'content'
+      notifies node['foo']['bar'], 'service[httpd]', :delayed
+    end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+
+  context "with a resource that notifies using an action that is a resource property" do
+    recipe_file <<-EOF
+    file '/tmp/a.txt' do
+      content 'content'
+      notifies new_resource.bob, 'service[httpd]', :delayed
+    end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+
+  context "with a resource that notifies using an action that is a variable" do
+    recipe_file <<-EOF
+      file '/tmp/a.txt' do
+        content 'content'
+        notifies foo, 'service[httpd]', :delayed
+      end
+      EOF
+    it { is_expected.not_to violate_rule }
+  end
+
+  context "with a resource that notifies with a variable in a loop" do
+    recipe_file <<-EOF
+      file '/tmp/a.txt' do
+        content 'content'
+        Array(node['foo']['bar']).each do |action|
+          notifies action, 'service[httpd]', :delayed
+        end
+      end
+      EOF
+    it { is_expected.not_to violate_rule }
+  end
+end

--- a/spec/functional/fc037_spec.rb
+++ b/spec/functional/fc037_spec.rb
@@ -21,6 +21,16 @@ describe "FC037" do
     it { is_expected.not_to violate_rule }
   end
 
+  context "with a resource that notifies using an action as a :'symbol'" do
+    recipe_file <<-EOF
+    file '/tmp/a.txt' do
+      content 'content'
+      notifies :'restart', 'service[httpd]', :delayed
+    end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+
   context "with a resource that notifies using an action that is an attribute" do
     recipe_file <<-EOF
     file '/tmp/a.txt' do


### PR DESCRIPTION
So this initially started as a simple new rule until I realized that our entire system for parsing out actions in notifications was flawed. It turned everything into a symbol even if it wasn't a symbol. So now it sorta does the right thing:

Find strings and pass them as strings
Find symbols and pass them as symbols
Find variables like node attributes and pass them as nil since we can't do anything with those and parsing them out is really hard

With this new data we should probably avoid some FC037 false positives and we're now alerting if you send an action as a string which was happening in 2 places on the Supermarket and up until 13.7 potentially led to double notifications.