### PR TITLE
Corrects a typo in the tests for FC007

### DIFF
--- a/spec/functional/fc007_spec.rb
+++ b/spec/functional/fc007_spec.rb
@@ -76,7 +76,7 @@ describe "FC007" do
   end
 
   context "with an include from the same cookbook" do
-    recipe_file 'incldue_recipe "test::other"'
+    recipe_file 'include_recipe "test::other"'
     it { is_expected.to_not violate_rule }
 
     context "with the shorthand syntax" do


### PR DESCRIPTION
This example was passing, but because it was not finding an
`include_recipe`, rather than finding a local use of `include_recipe`.

Signed-off-by: Richard Clamp <richardc@unixbeard.net>