### PR TITLE
Take chef12 tags off issue_url and source_url

### DIFF
--- a/lib/foodcritic/rules/fc064.rb
+++ b/lib/foodcritic/rules/fc064.rb
@@ -1,5 +1,5 @@
 rule "FC064", "Ensure issues_url is set in metadata" do
-  tags %w{metadata supermarket chef12}
+  tags %w{metadata supermarket}
   metadata do |ast, filename|
     [file_match(filename)] unless field(ast, "issues_url").any?
   end

--- a/lib/foodcritic/rules/fc065.rb
+++ b/lib/foodcritic/rules/fc065.rb
@@ -1,5 +1,5 @@
 rule "FC065", "Ensure source_url is set in metadata" do
-  tags %w{metadata supermarket chef12}
+  tags %w{metadata supermarket}
   metadata do |ast, filename|
     [file_match(filename)] unless field(ast, "source_url").any?
   end


### PR DESCRIPTION
People shouldn't think they need these to use Chef 12. They're just
useful.

Signed-off-by: Tim Smith <tsmith@chef.io>