### PR TITLE
Fixup failing travis on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
 
 # this avoids build issues with rainbow on old bundler/rubygems
 before_install:
-  #- gem update --system
+  - gem update --system
   - gem --version
   - rvm @global do gem uninstall bundler -a -x -I || true
   - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem "minitest", "~> 5.3"
   gem "minitest-reporters"
   gem "simplecov", "~> 0.8"
-  gem "chefstyle", "~> 0.5"
+  gem "chefstyle", "~> 0.5.0"
 end
 
 group :development do


### PR DESCRIPTION
Master is currently failing on travis:

* The latest release of rubocop adds new style checks, so the rubocop target was failing
* The recipe for removing other versions of bundler was not working under RVM 2.5.0, leading to two installs of bundler.

Here we:

* pins rubocop to the last known compatible release based on travis logs
* Adopts an approach from https://github.com/travis-ci/travis-ci/issues/8717#issuecomment-366500378 to 'uninstall' bundler from RVM 2.5.0