### PR TITLE
Force UTF8 encoding

### DIFF
--- a/lib/foodcritic.rb
+++ b/lib/foodcritic.rb
@@ -1,3 +1,6 @@
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 require "pathname"
 require "cucumber/core"
 require "treetop"


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

For example, when you're running in a container you don't control that doesn't have a utf8 locale set.

example:
```
LC_ALL=C foodcritic .
Checking 48 files
bundler: failed to load command: foodcritic (<snip>/.chefdk/gem/ruby/2.4.0/bin/foodcritic)
ArgumentError: invalid byte sequence in US-ASCII
```