### PR TITLE
Report the file that failed to parse on parsing errors

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -557,7 +557,11 @@ module FoodCritic
                else
                  File.read(file).encode("utf-8", "binary", :undef => :replace)
                end
-      build_xml(Ripper::SexpBuilder.new(source).parse)
+      begin
+        build_xml(Ripper::SexpBuilder.new(source).parse)
+      rescue RuntimeError => e # this generally means bad encoding
+        raise "Could not parse the file at #{file}. #{e}"
+      end
     end
 
     # XPath custom function


### PR DESCRIPTION
Right now if you provide a repo with a file that can't be parsed we just
fail, leaving you to figure out what file was bad. With this change we
rescue and report the failure.

Signed-off-by: Tim Smith <tsmith@chef.io>