### PR TITLE
Add FC122: Use the build_essential resource instead of the recipe

### DIFF
--- a/lib/foodcritic/rules/fc122.rb
+++ b/lib/foodcritic/rules/fc122.rb
@@ -1,0 +1,6 @@
+rule "FC122", "Use the build_essential resource instead of the recipe" do
+  tags %w{correctness}
+  recipe do |ast|
+    ast.xpath("//command[ident/@value = 'include_recipe']/descendant::tstring_content[@value='build-essential' or @value='build-essential::default']")
+  end
+end

--- a/spec/functional/fc122_spec.rb
+++ b/spec/functional/fc122_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "FC122" do
+  context "with a recipe that includes build-essential" do
+    recipe_file "include_recipe 'build-essential'"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a recipe that includes build-essential::default" do
+    recipe_file "include_recipe 'build-essential::default'"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a recipe that includes build-essential-mycorp" do
+    recipe_file "include_recipe 'build-essential-mycorp'"
+    it { is_expected.to_not violate_rule }
+  end
+end


### PR DESCRIPTION
This gets people ready to use the built in build_essential resource in
Chef 14

Signed-off-by: Tim Smith <tsmith@chef.io>