### PR TITLE
Add FC116: Cookbook depends on the deprecated compat_resource cookbook

### DIFF
--- a/lib/foodcritic/rules/fc116.rb
+++ b/lib/foodcritic/rules/fc116.rb
@@ -1,0 +1,6 @@
+rule "FC116", "Cookbook depends on the deprecated compat_resource cookbook" do
+  tags %w{deprecated}
+  metadata do |ast, filename|
+    [file_match(filename)] if declared_dependencies(ast).include?("compat_resource")
+  end
+end

--- a/spec/functional/fc116_spec.rb
+++ b/spec/functional/fc116_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe "FC116" do
+  context "with metadata depending on compat_resource" do
+    metadata_file "name 'test'\ndepends 'compat_resource'"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with metadata depending on foo" do
+    metadata_file "name 'test'\ndepends 'foo'"
+    it { is_expected.to_not violate_rule }
+  end
+
+  context "with metadata depending on nothing" do
+    metadata_file "name 'test'"
+    it { is_expected.to_not violate_rule }
+  end
+end


### PR DESCRIPTION
compat_resource isn't required with later released of Chef 12 and should
not be used in modern cookbooks.

Signed-off-by: Tim Smith <tsmith@chef.io>