### PR TITLE
Add FC120: Do not set the name property directly on a resource

### DIFF
--- a/lib/foodcritic/rules/fc120.rb
+++ b/lib/foodcritic/rules/fc120.rb
@@ -1,0 +1,6 @@
+rule "FC120", "Do not set the name property directly on a resource" do
+  tags %w{correctness}
+  recipe do |ast|
+    find_resources(ast).xpath('(.//command|.//fcall)[ident/@value="name"]')
+  end
+end

--- a/spec/functional/fc120_spec.rb
+++ b/spec/functional/fc120_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "FC120" do
+  context "with a resource that sets the name property" do
+    recipe_file <<-EOF
+    foo 'bar' do
+      name 'Administrator'
+    end
+    EOF
+    it { is_expected.to violate_rule }
+  end
+
+  context "with a resource that does not set the name property" do
+    recipe_file <<-EOF
+    foo 'bar' do
+      foo_name 'Administrator'
+    end
+    EOF
+    it { is_expected.not_to violate_rule }
+  end
+end


### PR DESCRIPTION
People need to stop doing this and they don't know better right now.

Signed-off-by: Tim Smith <tsmith@chef.io>