### PR TITLE
Fix 2 bugs in calculating the cookbook dir from cookbook fles

### DIFF
--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -264,8 +264,14 @@ module FoodCritic
       # we didn't find something in cache so look it up and cache it for later
       cook_val = Pathname.new(File.join(File.dirname(file),
                                         case File.basename(file)
-                                        when "metadata.rb" then ""
-                                        when /\.erb$/ then "../.."
+                                        when "recipe.rb", "attribute.rb", "metadata.rb" then ""
+                                        when /\.erb$/
+                                          if File.exist?(File.join(File.dirname(file), "../../metadata.rb")) ||
+                                             File.exist?(File.join(File.dirname(file), "../../metadata.json"))
+                                            "../.." # we're in a subdir in the templates dir (Chef < 12 style)
+                                          else
+                                            ".." # the erb is directly in the templates directory (Chef 12+ style)
+                                          end
                                         else ".."
                                         end)).cleanpath
       @dir_cache[abs_file] = cook_val

--- a/spec/unit/linter_spec.rb
+++ b/spec/unit/linter_spec.rb
@@ -16,6 +16,28 @@ describe FoodCritic::Linter do
     end
   end
 
+  describe "#cookbook_dir" do
+    it "given a root alias file the cookbook is correctly detected" do
+      expect(linter.send(:cookbook_dir, "./cookbook/recipe.rb").to_s).to eq "cookbook"
+    end
+
+    it "given the metadata.rb file the cookbook is correctly detected" do
+      expect(linter.send(:cookbook_dir, "./cookbook/metadata.rb").to_s).to eq "cookbook"
+    end
+
+    it "given a template nested multiple levels deep the cookbook is correctly detected" do
+      expect(linter.send(:cookbook_dir, "./cookbook/templates/foo/bar/file.erb").to_s).to eq "./cookbook"
+    end
+
+    it "given a template directly in the templates directory the cookbook is correctly detected" do
+      expect(linter.send(:cookbook_dir, "./cookbook/templates/file.erb").to_s).to eq "./cookbook"
+    end
+
+    it "given a standard recipe file the cookbook is correctly detected" do
+      expect(linter.send(:cookbook_dir, "./cookbook/recipes/default.rb").to_s).to eq "cookbook"
+    end
+  end
+
   describe "#check" do
     it "requires a cookbook_path, role_path or environment_path to be specified" do
       expect { linter.check({}) }.to raise_error ArgumentError


### PR DESCRIPTION
Both of these bugs happened when you matched on cookbook:

If you used the Chef 13+ recipe.rb or attribute.rb files we would end up 1 directory above the cookbook which would cause rules to fail
If you placed you templates directly in the templates directory you would end up 1 directory above the cookbook which would cause rules to fail

Signed-off-by: Tim Smith <tsmith@chef.io>