### PR TITLE
Fix rules to have the deprecated tag not deprecation

### DIFF
--- a/lib/foodcritic/rules/fc106.rb
+++ b/lib/foodcritic/rules/fc106.rb
@@ -1,5 +1,5 @@
 rule "FC106", "Use the plist_hash property in launchd instead of hash" do
-  tags %w{deprecation chef13}
+  tags %w{deprecated chef13}
   recipe do |ast|
     find_resources(ast, type: "launchd").find_all do |launchd_resource|
       resource_attribute(launchd_resource, "hash")

--- a/lib/foodcritic/rules/fc110.rb
+++ b/lib/foodcritic/rules/fc110.rb
@@ -1,5 +1,5 @@
 rule "FC110", "Script resources should use 'code' property not 'command' property" do
-  tags %w{deprecation chef13}
+  tags %w{deprecated chef13}
   recipe do |ast|
     script_resources = %w{ bash
                            ksh

--- a/lib/foodcritic/rules/fc111.rb
+++ b/lib/foodcritic/rules/fc111.rb
@@ -1,5 +1,5 @@
 rule "FC111", "search using deprecated sort flag" do
-  tags %w{deprecation chef13}
+  tags %w{deprecated chef13}
   recipe do |ast|
     # search(:node, 'role:web', :sort => true)
     ast.xpath("//method_add_arg[fcall/ident/@value='search'][arg_paren/args_add_block/args_add/bare_assoc_hash/assoc_new/symbol/ident/@value = 'sort']")

--- a/lib/foodcritic/rules/fc112.rb
+++ b/lib/foodcritic/rules/fc112.rb
@@ -1,5 +1,5 @@
 rule "FC112", "Resource using deprecated dsl_name method" do
-  tags %w{deprecation chef13}
+  tags %w{deprecated chef13}
   recipe do |ast|
     ast.xpath("//call/ident[@value='dsl_name']")
   end

--- a/lib/foodcritic/rules/fc113.rb
+++ b/lib/foodcritic/rules/fc113.rb
@@ -1,5 +1,5 @@
 rule "FC113", "Resource declares deprecated use_inline_resources" do
-  tags %w{deprecation chef15 lwrp}
+  tags %w{deprecated chef15 lwrp}
   library do |ast|
     matches = []
     ast.xpath('//const_path_ref/const[@value="LWRPBase"]/..//const[@value="Provider"]/../../..').select do |x|

--- a/lib/foodcritic/rules/fc119.rb
+++ b/lib/foodcritic/rules/fc119.rb
@@ -1,5 +1,5 @@
 rule "FC119", "windows_task :change action no longer exists in Chef 13" do
-  tags %w{deprecation chef13}
+  tags %w{deprecated chef13}
   recipe do |ast|
     matches = []
     find_resources(ast).each do |resource|


### PR DESCRIPTION
This gives us a consistent tag

Signed-off-by: Tim Smith <tsmith@chef.io>