### PR TITLE
Add FC121: Cookbook depends on cookbook made obsolete by Chef 14

### DIFF
--- a/lib/foodcritic/rules/fc121.rb
+++ b/lib/foodcritic/rules/fc121.rb
@@ -1,6 +1,6 @@
 rule "FC121", "Cookbook depends on cookbook where resources are built into Chef 14" do
   tags %w{correctness}
   metadata do |ast, filename|
-    [file_match(filename)] unless (declared_dependencies(ast) & %w(build-essential dmg chef_handler chef_hostname mac_os_x swap sysctl)).empty?
+    [file_match(filename)] unless (declared_dependencies(ast) & %w{build-essential dmg chef_handler chef_hostname mac_os_x swap sysctl}).empty?
   end
 end

--- a/lib/foodcritic/rules/fc121.rb
+++ b/lib/foodcritic/rules/fc121.rb
@@ -1,0 +1,6 @@
+rule "FC121", "Cookbook depends on cookbook where resources are built into Chef 14" do
+  tags %w{correctness}
+  metadata do |ast, filename|
+    [file_match(filename)] unless (declared_dependencies(ast) & %w(build-essential dmg chef_handler chef_hostname mac_os_x swap sysctl)).empty?
+  end
+end

--- a/lib/foodcritic/rules/fc121.rb
+++ b/lib/foodcritic/rules/fc121.rb
@@ -1,4 +1,4 @@
-rule "FC121", "Cookbook depends on cookbook where resources are built into Chef 14" do
+rule "FC121", "Cookbook depends on cookbook made obsolete by Chef 14" do
   tags %w{correctness}
   metadata do |ast, filename|
     [file_match(filename)] unless (declared_dependencies(ast) & %w{build-essential dmg chef_handler chef_hostname mac_os_x swap sysctl}).empty?

--- a/spec/functional/fc121_spec.rb
+++ b/spec/functional/fc121_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe "FC121" do
+  context "with metadata depending on build-essential" do
+    metadata_file "name 'test'\ndepends 'build-essential'"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with metadata depending on swap" do
+    metadata_file "name 'test'\ndepends 'swap'"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with metadata depending on dmg" do
+    metadata_file "name 'test'\ndepends 'dmg'"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with metadata depending on mac_os_x" do
+    metadata_file "name 'test'\ndepends 'mac_os_x'"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with metadata depending on chef_handler" do
+    metadata_file "name 'test'\ndepends 'chef_handler'"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with metadata depending on chef_hostname" do
+    metadata_file "name 'test'\ndepends 'chef_hostname'"
+    it { is_expected.to violate_rule }
+  end
+
+  context "with metadata depending on foo" do
+    metadata_file "name 'test'\ndepends 'foo'"
+    it { is_expected.to_not violate_rule }
+  end
+
+  context "with metadata depending on nothing" do
+    metadata_file "name 'test'"
+    it { is_expected.to_not violate_rule }
+  end
+end

--- a/spec/regression/expected/ark.txt
+++ b/spec/regression/expected/ark.txt
@@ -1,4 +1,4 @@
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
 FC113: Resource declares deprecated use_inline_resources: ./providers/default.rb:25
-FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
+FC121: Cookbook depends on cookbook made obsolete by Chef 14: ./metadata.rb:1

--- a/spec/regression/expected/ark.txt
+++ b/spec/regression/expected/ark.txt
@@ -1,3 +1,4 @@
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
 FC113: Resource declares deprecated use_inline_resources: ./providers/default.rb:25
+FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1

--- a/spec/regression/expected/chef_nginx.txt
+++ b/spec/regression/expected/chef_nginx.txt
@@ -1,4 +1,5 @@
 FC015: Consider converting definition to a Custom Resource: ./definitions/nginx_site.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
+FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/source.rb:38

--- a/spec/regression/expected/chef_nginx.txt
+++ b/spec/regression/expected/chef_nginx.txt
@@ -1,5 +1,5 @@
 FC015: Consider converting definition to a Custom Resource: ./definitions/nginx_site.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
-FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
+FC121: Cookbook depends on cookbook made obsolete by Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/source.rb:38

--- a/spec/regression/expected/gecode.txt
+++ b/spec/regression/expected/gecode.txt
@@ -7,5 +7,5 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
-FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
+FC121: Cookbook depends on cookbook made obsolete by Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/source.rb:20

--- a/spec/regression/expected/gecode.txt
+++ b/spec/regression/expected/gecode.txt
@@ -7,4 +7,5 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
+FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/source.rb:20

--- a/spec/regression/expected/mysql.txt
+++ b/spec/regression/expected/mysql.txt
@@ -16,4 +16,5 @@ FC082: Deprecated node.set or node.set_unless used to set node attributes: ./rec
 FC082: Deprecated node.set or node.set_unless used to set node attributes: ./recipes/server.rb:39
 FC082: Deprecated node.set or node.set_unless used to set node attributes: ./recipes/server.rb:40
 FC082: Deprecated node.set or node.set_unless used to set node attributes: ./recipes/server.rb:41
+FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/ruby.rb:29

--- a/spec/regression/expected/mysql.txt
+++ b/spec/regression/expected/mysql.txt
@@ -16,5 +16,5 @@ FC082: Deprecated node.set or node.set_unless used to set node attributes: ./rec
 FC082: Deprecated node.set or node.set_unless used to set node attributes: ./recipes/server.rb:39
 FC082: Deprecated node.set or node.set_unless used to set node attributes: ./recipes/server.rb:40
 FC082: Deprecated node.set or node.set_unless used to set node attributes: ./recipes/server.rb:41
-FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
+FC121: Cookbook depends on cookbook made obsolete by Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/ruby.rb:29

--- a/spec/regression/expected/passenger_apache2.txt
+++ b/spec/regression/expected/passenger_apache2.txt
@@ -28,5 +28,5 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
-FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
+FC121: Cookbook depends on cookbook made obsolete by Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/default.rb:26

--- a/spec/regression/expected/passenger_apache2.txt
+++ b/spec/regression/expected/passenger_apache2.txt
@@ -28,4 +28,5 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
+FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/default.rb:26

--- a/spec/regression/expected/php.txt
+++ b/spec/regression/expected/php.txt
@@ -3,5 +3,5 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
-FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
+FC121: Cookbook depends on cookbook made obsolete by Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/source.rb:23

--- a/spec/regression/expected/php.txt
+++ b/spec/regression/expected/php.txt
@@ -3,4 +3,5 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
+FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/source.rb:23

--- a/spec/regression/expected/transmission.txt
+++ b/spec/regression/expected/transmission.txt
@@ -10,5 +10,5 @@ FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/torrent_file.rb:53
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/torrent_file.rb:58
-FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
+FC121: Cookbook depends on cookbook made obsolete by Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/source.rb:21

--- a/spec/regression/expected/transmission.txt
+++ b/spec/regression/expected/transmission.txt
@@ -10,4 +10,5 @@ FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/torrent_file.rb:53
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/torrent_file.rb:58
+FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/source.rb:21

--- a/spec/regression/expected/windows.txt
+++ b/spec/regression/expected/windows.txt
@@ -33,4 +33,4 @@ FC085: Resource using new_resource.updated_by_last_action to converge resource: 
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/task.rb:68
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/task.rb:79
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/zipfile.rb:41
-FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
+FC121: Cookbook depends on cookbook made obsolete by Chef 14: ./metadata.rb:1

--- a/spec/regression/expected/windows.txt
+++ b/spec/regression/expected/windows.txt
@@ -33,3 +33,4 @@ FC085: Resource using new_resource.updated_by_last_action to converge resource: 
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/task.rb:68
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/task.rb:79
 FC085: Resource using new_resource.updated_by_last_action to converge resource: ./providers/zipfile.rb:41
+FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1

--- a/spec/regression/expected/xml.txt
+++ b/spec/regression/expected/xml.txt
@@ -4,4 +4,5 @@ FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
 FC082: Deprecated node.set or node.set_unless used to set node attributes: ./recipes/ruby.rb:27
+FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/ruby.rb:28

--- a/spec/regression/expected/xml.txt
+++ b/spec/regression/expected/xml.txt
@@ -4,5 +4,5 @@ FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC078: Ensure cookbook shared under an OSI-approved open source license: ./metadata.rb:1
 FC082: Deprecated node.set or node.set_unless used to set node attributes: ./recipes/ruby.rb:27
-FC121: Cookbook depends on cookbook where resources are built into Chef 14: ./metadata.rb:1
+FC121: Cookbook depends on cookbook made obsolete by Chef 14: ./metadata.rb:1
 FC122: Use the build_essential resource instead of the recipe: ./recipes/ruby.rb:28


### PR DESCRIPTION
Check for users that are including cookbooks where the resources are
built into chef 14. I'm not tagging this with chef 14 since doing so
makes it seem like a thing you *must* fix to use chef 14. Getting rid of
these deps just speeds up chef and simplifies your depsolving a bit.

Signed-off-by: Tim Smith <tsmith@chef.io>