### PR TITLE
lock `cucumber-core` as there are breaking changes in 4.x

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files += Dir["spec/**/*"] + Dir["features/**/*"]
   s.files += Dir["*.md"] + Dir["LICENSE"] + Dir["man/*"]
 
-  s.add_dependency("cucumber-core", ">= 1.3")
+  s.add_dependency("cucumber-core", ">= 1.3", "< 4.0")
   s.add_dependency("nokogiri", ">= 1.5", "< 2.0")
   s.add_dependency("rake")
   s.add_dependency("treetop", "~> 1.4")


### PR DESCRIPTION
```
$ bundle exec rake -T
rake aborted!
LoadError: cannot load such file -- cucumber/core/gherkin/tag_expression
/home/babrams/projects/personal/redisio/Rakefile:14:in `require'
/home/babrams/projects/personal/redisio/Rakefile:14:in `block in <top (required)>'
/home/babrams/projects/personal/redisio/Rakefile:3:in `<top (required)>'
/home/babrams/.rbenv/versions/2.4.1/bin/bundle:22:in `load'
/home/babrams/.rbenv/versions/2.4.1/bin/bundle:22:in `<main>'
(See full trace by running task with --trace)
```

Here is the code that is not happy:
```
require 'foodcritic'
  desc 'Run Chef style checks'
  FoodCritic::Rake::LintTask.new(:chef) do |t|
    # 'search_gems' doesn't work, but :search_gems does
    # rubocop:disable Style/HashSyntax
    t.options = {
      :search_gems => true,
      :fail_tags => ['correctness'],
      :chef_version => '13.3.0',
      :tags => %w(
        ~FC059
        ~FC085
      )
    }
    # rubocop:enable Style/HashSyntax
  end
end
```

They moved `gherkin` from its own gem to an embedded project. This locks on the latest working major. I have not delved enough into how to solve this just how to get an existing setup working.

Signed-off-by: Ben Abrams <me@benabrams.it>