### PR TITLE
Allow configuring the size of the AST cache

### DIFF
--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -287,6 +287,11 @@ module FoodCritic
     def run_lint(cmd_args)
       cd "." do
         show_context = cmd_args.include?("-C")
+        # For tests, we need to disable the global AST cache (set it to size 0)
+        unless cmd_args.include?('-s') || cmd_args.include?('--ast-cache-size')
+          cmd_args.unshift('-s', '0')
+        end
+
         review, @status = FoodCritic::Linter.run(CommandLine.new(cmd_args))
         @review =
           if review.nil? || (review.respond_to?(:warnings) && review.warnings.empty?)

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -258,7 +258,7 @@ module FoodCritic
     # @since 16.1
     # @param size [Integer] the size of the cache (will be resized)
     def ast_cache(size = nil)
-      @@ast_cache ||= Rufus::Lru::Hash.new(size)
+      @@ast_cache ||= Rufus::Lru::Hash.new(size || 5)
       if size && @@ast_cache.maxsize != size
         @@ast_cache.maxsize = size
       end

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -254,14 +254,16 @@ module FoodCritic
         line: pos["line"].to_i, column: pos["column"].to_i }
     end
 
+    def ast_cache(size = nil)
+      @@ast_cache ||= Rufus::Lru::Hash.new(size)
+      if size && @@ast_cache.maxsize != size
+        @@ast_cache.maxsize = size
+      end
+      @@ast_cache
+    end
     # Read the AST for the given Ruby source file
     def read_ast(file)
-      @ast_cache ||= Rufus::Lru::Hash.new(5)
-      if @ast_cache.include?(file)
-        @ast_cache[file]
-      else
-        @ast_cache[file] = uncached_read_ast(file)
-      end
+      ast_cache[file] ||= uncached_read_ast(file)
     end
 
     # Retrieve a single-valued attribute from the specified resource.

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -254,6 +254,9 @@ module FoodCritic
         line: pos["line"].to_i, column: pos["column"].to_i }
     end
 
+    # Returns a global LRU cache holding the AST of a file
+    # @since 16.1
+    # @param size [Integer] the size of the cache (will be resized)
     def ast_cache(size = nil)
       @@ast_cache ||= Rufus::Lru::Hash.new(size)
       if size && @@ast_cache.maxsize != size

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -264,6 +264,7 @@ module FoodCritic
       end
       @@ast_cache
     end
+
     # Read the AST for the given Ruby source file
     def read_ast(file)
       ast_cache[file] ||= uncached_read_ast(file)

--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -51,7 +51,7 @@ module FoodCritic
                 "Specify file with rules to be used or ignored ") do |c|
           @options[:rule_file] = c
         end
-        opts.on("-s", "--ast-cache-size", Integer,
+        opts.on("-s", "--ast-cache-size NUM", Integer,
                 "Change the size of the AST cache.") do |s|
           @options[:ast_cache_size] = s
         end

--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -24,6 +24,7 @@ module FoodCritic
         environment_paths: [],
         exclude_paths: ["test/**/*", "spec/**/*", "features/**/*"],
         progress: true,
+        ast_cache_size: 5,
       }
       @parser = OptionParser.new do |opts|
         opts.banner = "foodcritic [cookbook_paths]"
@@ -49,6 +50,10 @@ module FoodCritic
         opts.on("-r", "--rule-file PATH",
                 "Specify file with rules to be used or ignored ") do |c|
           @options[:rule_file] = c
+        end
+        opts.on("-s", "--ast-cache-size", Integer,
+                "Change the size of the AST cache.") do |s|
+          @options[:ast_cache_size] = s
         end
         opts.on("-B", "--cookbook-path PATH",
                 "Cookbook path(s) to check.") do |b|

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -68,6 +68,7 @@ module FoodCritic
       options = setup_defaults(options)
       @options = options
       @chef_version = options[:chef_version] || DEFAULT_CHEF_VERSION
+      ast_cache(options[:ast_cache_size])
 
       warnings = []; last_dir = nil; matched_rule_tags = Set.new
       load_rules

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,8 +43,8 @@ module FunctionalHelpers
       Dir.chdir(temp_path)
       $stderr = error
       # For tests, we need to disable the global AST cache (set it to size 0)
-      unless args.include?('-s') || args.include?('--ast-cache-size')
-        args.unshift('-s', '0')
+      unless args.include?("-s") || args.include?("--ast-cache-size")
+        args.unshift("-s", "0")
       end
       exitstatus = FoodCritic::CommandLine.main(args, output)
     ensure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,10 @@ module FunctionalHelpers
       cwd = Dir.pwd
       Dir.chdir(temp_path)
       $stderr = error
+      # For tests, we need to disable the global AST cache (set it to size 0)
+      unless args.include?('-s') || args.include?('--ast-cache-size')
+        args.unshift('-s', '0')
+      end
       exitstatus = FoodCritic::CommandLine.main(args, output)
     ensure
       $stderr = STDERR

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -18,6 +18,7 @@ describe FoodCritic::Api do
     end
     it "exposes the expected api to rule authors" do
       expect(api.public_methods.sort - ignorable_methods).to eq [
+        :ast_cache,
         :attribute_access,
         :chef_dsl_methods,
         :chef_node_methods,


### PR DESCRIPTION
Also, make the cache unique, so if people want to use read_ast in a rule, it will use the same cache

Otherwise, it can get really slow if people check dependencies using AST. The default of 5 will keep the memory footprint low and should be fine for most people