### PR TITLE
Checks if the content of the files dir has any file above 1MB

### DIFF
--- a/lib/foodcritic/rules/fc123.rb
+++ b/lib/foodcritic/rules/fc123.rb
@@ -1,0 +1,14 @@
+rule "FC123", "Content of files/ is larger than 1MB" do
+  tags %w{files}
+  cookbook do |path|
+    values = []
+    Dir.foreach(File.join(path, "files")) do |file|
+      next if ['.', '..'].member?(file)
+      size = File.size(File.join(path,'files',file))
+      if size > 1024*1024 # 1 megabyte
+        values += [file_match(File.join(path,'files',file))]
+      end
+    end
+    values
+  end
+end


### PR DESCRIPTION
Output looks like this:
```
foodcritic test -I lib/foodcritic/rules/
Checking 11 files
..........x
FC123: Content of files/ is larger than 1MB: /Users/mattray/ws/foodcritic/test/files/Testing_Terraform_With_InSpec.pdf:1
FC123: Content of files/ is larger than 1MB: /Users/mattray/ws/foodcritic/test/files/container.training-master.zip:1
```

Signed-off-by: Matt Ray <matthewhray@gmail.com>