### PR TITLE
Fix :'symbol' action in notification detection on Ruby 2.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: ruby
 cache: bundler
 rvm:
   - 2.3.8
-  - 2.4.5
-  - 2.5.5
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 
 bundler_args: --jobs 3 --retry 3
 branches:

--- a/lib/foodcritic/notifications.rb
+++ b/lib/foodcritic/notifications.rb
@@ -133,7 +133,8 @@ module FoodCritic
       is_variable = true unless notify.xpath("args_add_block/args_add//args_add[aref or vcall or call or var_ref]").empty?
       string_val = notify.xpath("descendant::args_add/string_literal/string_add/tstring_content/@value").first
       symbol_val = notify.xpath('descendant::args_add/args_add//symbol/ident/@value |
-        descendant::dyna_symbol[1]/xstring_add/tstring_content/@value').first
+        descendant::dyna_symbol[1]/xstring_add/tstring_content/@value |
+        descendant::args_add/args_add//dyna_symbol/string_add/tstring_content/@value').first
 
       # 1) return a nil if the action is a variable like node['foo']['bar']
       # 2) return the symbol if it exists


### PR DESCRIPTION
The AST changed as it often does between ruby releases and this broke FC037 and other cops that relied on this weird pattern. The solution: make the xpath query even worse.

Signed-off-by: Tim Smith <tsmith@chef.io>