### PR TITLE
Foodcritic going away warning message

### DIFF
--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -172,6 +172,7 @@ module FoodCritic
     # @param [Boolean] is_exit_zero The exit code to check for.
     def usage_displayed(is_exit_zero)
       expect_output "foodcritic [cookbook_paths]"
+      expect_output "WARNING: Foodcritic will end of life in April 2020"
 
       usage_options.each do |option|
         expect_usage_option(option[:short], option[:long], option[:description])

--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -117,7 +117,7 @@ module FoodCritic
     def show_end_of_life_msg
       "
     *******************************************************************************
-    WARNING: Foodcritic will end of life in April 2020
+    WARNING: Foodcritic will be end of life in April 2020
     *******************************************************************************
     Please use Cookstyle to ensure all of your Chef Infra code meets the latest
     best practices.

--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -111,6 +111,26 @@ module FoodCritic
       end
     end
 
+    # The end of life message.
+    #
+    # @return [String] A text to warn end users about foodcritic's end of life
+    def show_end_of_life_msg
+      "
+    *******************************************************************************
+    WARNING: Foodcritic will end of life in April 2020
+    *******************************************************************************
+    Please use Cookstyle to ensure all of your Chef Infra code meets the latest
+    best practices.
+
+    Cookstyle is a code linting tool that helps you to write better Chef Infra
+    Cookbooks by detecting and automatically correct cookbook code.
+
+    For more information, use the command:
+
+    cookstyle -h
+      "
+    end
+
     # Show the command help to the end user?
     #
     # @return [Boolean] True if help should be shown.
@@ -118,11 +138,11 @@ module FoodCritic
       @args.length == 1 && @args.first == "--help"
     end
 
-    # The help text.
+    # The help text plus the end of life message.
     #
     # @return [String] Help text describing the command-line options available.
     def help
-      @parser.help
+      @parser.help + show_end_of_life_msg
     end
 
     # Show the current version to the end user?


### PR DESCRIPTION
In preparation for Foodcritic EOL planned for Apr 2020, we will provide
a warning message to let users know in advance.

Closes https://github.com/chef/chef-workstation/issues/697

### Screenshot:
![image](https://user-images.githubusercontent.com/5712253/70325091-798d7800-1831-11ea-97f0-eb0c9c0ea09c.png)

Signed-off-by: Salim Afiune <afiune@chef.io>